### PR TITLE
feat(before-send): ability to dismiss error

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ window.hawk = new HawkCatcher({
 })
 ```
 
+## Dismiss error
+
+You can use the `beforeSend()` hook to prevent sending a particular event. Return `false` for that.
+
 ## Integrate to Vue application
 
 Vue apps have their own error handler, so if you want to catcher errors thrown inside Vue components, you should set up a Vue integration.

--- a/example/index.html
+++ b/example/index.html
@@ -152,7 +152,7 @@
     <br><br>
     <button id="btn-console-test">Make</button>
 </section>
-<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue@2"></script>
 <section>
     <h2>Test Vue integration: $root</h2>
     <div id="vue-app-1">
@@ -227,8 +227,8 @@
 <script src="sample-errors.js"></script>
 <script>
   window.hawk = new HawkCatcher({
-    token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0SWQiOiI1ZTVhNzVjNzNlM2E5ZDE2YjUzMzczOTMiLCJpYXQiOjE1ODI5ODY2OTV9.oK_LPRxcpRuZE8eSbmdObRX712YXO_Twpq7mgg7-9pw',
-    collectorEndpoint: 'ws://localhost:3000/ws',
+    token: 'eyJpbnRlZ3JhdGlvbklkIjoiNWU5OTE1MzItZTdiYy00ZjA0LTliY2UtYmIzZmE5ZTUwMTg3Iiwic2VjcmV0IjoiMTBlMTA4MjQtZTcyNC00YWFkLTkwMDQtMzExYTU1OWMzZTIxIn0=',
+    // collectorEndpoint: 'ws://localhost:3000/ws',
     vue: window.Vue,
     context: {
       rootContextSample: '12345'

--- a/example/index.html
+++ b/example/index.html
@@ -228,7 +228,7 @@
 <script>
   window.hawk = new HawkCatcher({
     token: 'eyJpbnRlZ3JhdGlvbklkIjoiNWU5OTE1MzItZTdiYy00ZjA0LTliY2UtYmIzZmE5ZTUwMTg3Iiwic2VjcmV0IjoiMTBlMTA4MjQtZTcyNC00YWFkLTkwMDQtMzExYTU1OWMzZTIxIn0=',
-    // collectorEndpoint: 'ws://localhost:3000/ws',
+    collectorEndpoint: 'ws://localhost:3000/ws',
     vue: window.Vue,
     context: {
       rootContextSample: '12345'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "JavaScript errors tracking for Hawk.so",
   "main": "./dist/hawk.js",
   "types": "./dist/index.d.ts",

--- a/src/catcher.ts
+++ b/src/catcher.ts
@@ -66,6 +66,7 @@ export default class Catcher {
 
   /**
    * This Method allows developer to filter any data you don't want sending to Hawk
+   * If method returns false, event will not be sent
    */
   private readonly beforeSend: (event: EventData<JavaScriptAddons>) => EventData<JavaScriptAddons> | false;
 

--- a/src/catcher.ts
+++ b/src/catcher.ts
@@ -15,6 +15,7 @@ import {
   Json, EventData, EncodedIntegrationToken, DecodedIntegrationToken
 } from '@hawk.so/types';
 import { JavaScriptCatcherIntegrations } from './types/integrations';
+import { EventRejectedError } from './errors';
 
 /**
  * Allow to use global VERSION, that will be overwritten by Webpack
@@ -66,7 +67,7 @@ export default class Catcher {
   /**
    * This Method allows developer to filter any data you don't want sending to Hawk
    */
-  private readonly beforeSend: (event: EventData<JavaScriptAddons>) => EventData<JavaScriptAddons>;
+  private readonly beforeSend: (event: EventData<JavaScriptAddons>) => EventData<JavaScriptAddons> | false;
 
   /**
    * Transport for dialog between Catcher and Collector
@@ -246,8 +247,15 @@ export default class Catcher {
       }
 
       this.sendErrorFormatted(errorFormatted);
-    } catch (formattingError) {
-      log('Internal error ლ(´ڡ`ლ)', 'error', formattingError);
+    } catch (e) {
+      if (e instanceof EventRejectedError) {
+        /**
+         * Event was rejected by user using the beforeSend method
+         */
+        return;
+      }
+
+      log('Internal error ლ(´ڡ`ლ)', 'error', e);
     }
   }
 
@@ -286,7 +294,15 @@ export default class Catcher {
      * Filter sensitive data
      */
     if (typeof this.beforeSend === 'function') {
-      payload = this.beforeSend(payload);
+      const beforeSendResult = this.beforeSend(payload);
+
+      if (beforeSendResult === false) {
+        throw new EventRejectedError('Event rejected by beforeSend method.');
+
+        return;
+      } else {
+        payload = beforeSendResult;
+      }
     }
 
     return {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Error triggered when event was rejected by beforeSend method
+ */
+export class EventRejectedError extends Error {
+  /**
+   * @param message - error message
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = 'EventRejectedError';
+  }
+}


### PR DESCRIPTION
Ability to prevent sending of a particular event added.

If user's `beforeSend()` hook will return `false`, event won't be sent