### PR TITLE
chore(types): export js catcher event type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "JavaScript errors tracking for Hawk.so",
   "main": "./dist/hawk.js",
   "types": "./dist/index.d.ts",

--- a/src/catcher.ts
+++ b/src/catcher.ts
@@ -12,7 +12,7 @@ import {
   EventContext,
   JavaScriptAddons,
   VueIntegrationAddons,
-  Json, EventData, EncodedIntegrationToken, DecodedIntegrationToken
+  Json, EncodedIntegrationToken, DecodedIntegrationToken
 } from '@hawk.so/types';
 import { JavaScriptCatcherIntegrations } from './types/integrations';
 import { EventRejectedError } from './errors';

--- a/src/catcher.ts
+++ b/src/catcher.ts
@@ -16,6 +16,7 @@ import {
 } from '@hawk.so/types';
 import { JavaScriptCatcherIntegrations } from './types/integrations';
 import { EventRejectedError } from './errors';
+import type { HawkJavaScriptEvent } from './types';
 
 /**
  * Allow to use global VERSION, that will be overwritten by Webpack
@@ -68,7 +69,7 @@ export default class Catcher {
    * This Method allows developer to filter any data you don't want sending to Hawk
    * If method returns false, event will not be sent
    */
-  private readonly beforeSend: (event: EventData<JavaScriptAddons>) => EventData<JavaScriptAddons> | false;
+  private readonly beforeSend: (event: HawkJavaScriptEvent) => HawkJavaScriptEvent | false;
 
   /**
    * Transport for dialog between Catcher and Collector
@@ -281,7 +282,7 @@ export default class Catcher {
    * @param context - any additional data passed by user
    */
   private async prepareErrorFormatted(error: Error | string, context?: EventContext): Promise<CatcherMessage> {
-    let payload: EventData<JavaScriptAddons> = {
+    let payload: HawkJavaScriptEvent = {
       title: this.getTitle(error),
       type: this.getType(error),
       release: this.getRelease(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import 'regenerator-runtime/runtime';
 import Catcher from './catcher';
 import { HawkInitialSettings, AffectedUser } from './types/hawk-initial-settings';
+import { HawkJavaScriptEvent } from './types/event';
 
 export default Catcher;
 
 export {
   HawkInitialSettings,
-  AffectedUser
+  AffectedUser,
+  HawkJavaScriptEvent
 };

--- a/src/types/catcher-message.ts
+++ b/src/types/catcher-message.ts
@@ -1,4 +1,4 @@
-import { EventData, JavaScriptAddons } from '@hawk.so/types';
+import type { HawkJavaScriptEvent } from './event';
 
 /**
  * Structure describing a message sending by Catcher
@@ -17,5 +17,5 @@ export default interface CatcherMessage {
   /**
    * All information about the event
    */
-  payload: EventData<JavaScriptAddons>;
+  payload: HawkJavaScriptEvent;
 }

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,6 @@
+import type { EventData, JavaScriptAddons } from '@hawk.so/types';
+
+/**
+ * Event will be sent to Hawk by Hawk JavaScript SDK
+ */
+export type HawkJavaScriptEvent = EventData<JavaScriptAddons>;

--- a/src/types/hawk-initial-settings.d.ts
+++ b/src/types/hawk-initial-settings.d.ts
@@ -1,4 +1,5 @@
-import {EventContext, AffectedUser, EventData, JavaScriptAddons} from '@hawk.so/types';
+import type { EventContext, AffectedUser } from '@hawk.so/types';
+import type { HawkJavaScriptEvent } from './event';
 
 /**
  * JS Catcher initial settings
@@ -63,7 +64,7 @@ export interface HawkInitialSettings {
   /**
    * This Method allows you to filter any data you don't want sending to Hawk
    */
-  beforeSend?(event: EventData<JavaScriptAddons>): EventData<JavaScriptAddons>;
+  beforeSend?(event: HawkJavaScriptEvent): HawkJavaScriptEvent;
 }
 
 export {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,9 @@
 import CatcherMessage from './catcher-message';
 import HawkInitialSettings from './hawk-initial-settings';
+import { HawkJavaScriptEvent } from './event';
 
 export {
   CatcherMessage,
-  HawkInitialSettings
+  HawkInitialSettings,
+  HawkJavaScriptEvent
 };


### PR DESCRIPTION
This PR exports `HawkJavaScriptEvent` — type of events being sent by JS Catcher