### PR TITLE
chore(sanitizer): improve big context handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "JavaScript errors tracking for Hawk.so",
   "main": "./dist/hawk.js",
   "types": "./dist/index.d.ts",

--- a/src/catcher.ts
+++ b/src/catcher.ts
@@ -298,8 +298,6 @@ export default class Catcher {
 
       if (beforeSendResult === false) {
         throw new EventRejectedError('Event rejected by beforeSend method.');
-
-        return;
       } else {
         payload = beforeSendResult;
       }

--- a/src/modules/sanitizer.ts
+++ b/src/modules/sanitizer.ts
@@ -89,7 +89,7 @@ export default class Sanitizer {
    */
   private static sanitizeArray(arr: any[], depth: number): any[] {
     /**
-     * If the maximum depth is reached, slice array to max length and add a placeholder
+     * If the maximum length is reached, slice array to max length and add a placeholder
      */
     const length = arr.length;
 

--- a/stats.txt
+++ b/stats.txt
@@ -1,3 +1,3 @@
   
-  Size: 7.37 KB with all dependencies, minified and gzipped
+  Size: 7.44 KB with all dependencies, minified and gzipped
   


### PR DESCRIPTION
Before: 

Sanitizer checks big object for JSON.serialize length and replace them for `<big object>`. If context contains big data (for example, api response), it got lost.

After:

Now big objects looks better:

1. All properties preserved
2. Max props length is required to achieve `<big object>`
3. Inner objects reaching max depth will be replaced by `<deep object>`
4. Arrays length limitation added. 

<img width="772" alt="image" src="https://github.com/user-attachments/assets/cae5a846-6230-4046-b635-0a8e44943804">
