### PR TITLE
fix(type): event properties can't be undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "JavaScript errors tracking for Hawk.so",
   "main": "./dist/hawk.js",
   "types": "./dist/index.d.ts",

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,4 +1,4 @@
-import type { EventData, JavaScriptAddons } from '@hawk.so/types';
+import type { AffectedUser, BacktraceFrame, EventContext, EventData, JavaScriptAddons } from '@hawk.so/types';
 
 /**
  * Event data with JS specific addons
@@ -14,37 +14,36 @@ export type HawkJavaScriptEvent = Omit<JSEventData, 'type' | 'release' | 'user' 
   /**
    * Event type: TypeError, ReferenceError etc
    */
-  type: JSEventData['type'];
+  type: 'errors/javascript';
 
   /**
    * Current release (aka version, revision) of an application
    */
-  release: JSEventData['release'] | null;
+  release: string | null;
 
   /**
    * Current authenticated user
    */
-  user: JSEventData['user'] | null;
+  user: AffectedUser | null;
 
   /**
    * Any other information collected and passed by user
    */
-  context: JSEventData['context'];
+  context: EventContext;
 
   /**
-   *
    * Catcher-specific information
    */
-  addons: JSEventData['addons'];
+  addons: JavaScriptAddons;
 
   /**
    * Stack
    * From the latest call to the earliest
    */
-  backtrace: JSEventData['backtrace'] | null;
+  backtrace: BacktraceFrame[] | null;
 
   /**
    * Catcher version
    */
-  catcherVersion: JSEventData['catcherVersion'];
+  catcherVersion: string;
 };


### PR DESCRIPTION
There was a problem in #105 : "undefined" was still inherited as type of event properties. This PR fixes that