### PR TITLE
fix: properly handle cyclic objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@hawk.so/types": "^0.1.20",
     "error-stack-parser": "^2.1.4",
+    "safe-stringify": "^1.1.1",
     "vite-plugin-dts": "^4.2.4"
   }
 }

--- a/src/addons/consoleCatcher.ts
+++ b/src/addons/consoleCatcher.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ConsoleLogEvent } from '@hawk.so/types';
+import safeStringify from 'safe-stringify';
 
 const createConsoleCatcher = (): {
   initConsoleCatcher: () => void;
@@ -69,7 +70,7 @@ const createConsoleCatcher = (): {
             method,
             timestamp: new Date(),
             type: method,
-            message: args.map((arg) => typeof arg === 'string' ? arg : JSON.stringify(arg)).join(' '),
+            message: args.map((arg) => typeof arg === 'string' ? arg : safeStringify(arg)).join(' '),
             stack,
             fileLine: stack.split('\n')[0]?.trim(),
           };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,6 +2619,11 @@ safe-regex-test@^1.0.3:
     es-errors "^1.3.0"
     is-regex "^1.1.4"
 
+safe-stringify@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/safe-stringify/-/safe-stringify-1.1.1.tgz#f4240f506d041f58374d6106e2a5850f6b1ce576"
+  integrity sha512-YSzQLuwp06fuvJD1h6+vVNFYZoXmDs5UUNPUbTvQK7Ap+L0qD4Vp+sN434C+pdS3prVVlUfQdNeiEIgxox/kUQ==
+
 semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"


### PR DESCRIPTION
I encountered the following error when logging objects with circular references:

```
[Error] <RouterView> @ component update – TypeError: JSON.stringify cannot serialize cyclic structures. — @hawk__so_javascript.js:766
TypeError: JSON.stringify cannot serialize cyclic structures. — @hawk__so_javascript.js:766
  stringify
  map
  (anonymous function) — @hawk__so_javascript.js:766
  warn$1 — chunk-U3LI7FBV.js:2116
  validateProp — chunk-U3LI7FBV.js:6468
  validateProps — chunk-U3LI7FBV.js:6440
  initProps — chunk-U3LI7FBV.js:6129
  setupComponent — chunk-U3LI7FBV.js:9942
  mountComponent — chunk-U3LI7FBV.js:7300
  processComponent — chunk-U3LI7FBV.js:7266
  patch — chunk-U3LI7FBV.js:6782
  mountChildren — chunk-U3LI7FBV.js:7014
  mountElement — chunk-U3LI7FBV.js:6937
  processElement — chunk-U3LI7FBV.js:6902
  patch — chunk-U3LI7FBV.js:6770
  mountChildren — chunk-U3LI7FBV.js:7014
```


This error occurs because `JSON.stringify` cannot handle cyclic structures, causing the application to crash when such objects are logged. 

To address this, my PR introduces the `safeStringify` function from the `safe-stringify` package (new dependency added). This utility safely serializes objects, replacing circular references with a `[Circular]` marker.
