### PR TITLE
fix(stack-parser): fix source code lines iterations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hawk.so/javascript",
   "type": "commonjs",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "JavaScript errors tracking for Hawk.so",
   "files": [
     "dist"

--- a/src/modules/stackParser.ts
+++ b/src/modules/stackParser.ts
@@ -80,7 +80,7 @@ export default class StackParser {
        * In some cases column number of the error stack trace frame would be less then 200, but source code is minified
        * For this cases we need to check, that all of the lines to collect have length less than 200 too
        */
-      for (const lineToCheck in lines.slice(lineFrom, lineTo)) {
+      lines.slice(lineFrom, lineTo).forEach((lineToCheck) => {
         if (lineToCheck.length > minifiedSourceCodeThreshold) {
           return null;
         } else {
@@ -91,7 +91,7 @@ export default class StackParser {
 
           extractedLineIndex += 1;
         }
-      }
+      });
 
       return sourceCodeLines;
     } catch (e) {


### PR DESCRIPTION
## Problem
If we use 
```typescript
for (i in list.slice(startIndex, endIndex)) {}
```
i gets values from 0 to `(endIndex - startIndex)`
this is why we were getting this broken stack trace (source code lines were just indexes)
<img width="965" alt="image" src="https://github.com/user-attachments/assets/68f3c3ab-82cf-497a-93a5-04542772741f" />

## Solution
- Used `list.slice(start, end).forEach(i => {})`