### PR TITLE
fix(console-tracker): resolve infinity loop issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hawk.so/javascript",
   "type": "commonjs",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "JavaScript errors tracking for Hawk.so",
   "files": [
     "dist"
@@ -47,9 +47,8 @@
     "vue": "^2"
   },
   "dependencies": {
-    "@hawk.so/types": "^0.1.20",
+    "@hawk.so/types": "^0.1.35",
     "error-stack-parser": "^2.1.4",
-    "safe-stringify": "^1.1.1",
     "vite-plugin-dts": "^4.2.4"
   }
 }

--- a/src/addons/consoleCatcher.ts
+++ b/src/addons/consoleCatcher.ts
@@ -1,8 +1,8 @@
 /**
  * @file Module for intercepting console logs with stack trace capture
  */
-import safeStringify from 'safe-stringify';
 import type { ConsoleLogEvent } from '@hawk.so/types';
+import Sanitizer from '../modules/sanitizer';
 
 /**
  * Creates a console interceptor that captures and formats console output
@@ -31,7 +31,13 @@ function createConsoleCatcher(): {
       return String(arg);
     }
 
-    return safeStringify(arg);
+    /**
+     * Sanitize the argument before stringifying to handle circular references, deep objects, etc
+     * And then it can be stringified safely
+     */
+    const sanitized = Sanitizer.sanitize(arg);
+
+    return JSON.stringify(sanitized);
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,10 +316,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@hawk.so/types@^0.1.20":
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/@hawk.so/types/-/types-0.1.20.tgz#90f4b3998ef5f025f5b99dae31da264d5bbe3450"
-  integrity sha512-3a07TekmgqOT9OKeMkqcV73NxzK1dS06pG66VaHO0f5DEEH2+SNfZErqe1v8hkLQIk+GkgZVZLtHqnskjQabuw==
+"@hawk.so/types@^0.1.35":
+  version "0.1.35"
+  resolved "https://registry.yarnpkg.com/@hawk.so/types/-/types-0.1.35.tgz#6afd416dced1cc3282d721ca5621bf452b27aea1"
+  integrity sha512-uMTAeu6DlRlk+oputJBjTlrm1GzOkIwlMfGhpdOp3sRWe/YPGD6nMYlb9MZoVN6Yee7RIpYD7It+DPeUPAyIFw==
   dependencies:
     "@types/mongodb" "^3.5.34"
 
@@ -2618,11 +2618,6 @@ safe-regex-test@^1.0.3:
     call-bind "^1.0.6"
     es-errors "^1.3.0"
     is-regex "^1.1.4"
-
-safe-stringify@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/safe-stringify/-/safe-stringify-1.1.1.tgz#f4240f506d041f58374d6106e2a5850f6b1ce576"
-  integrity sha512-YSzQLuwp06fuvJD1h6+vVNFYZoXmDs5UUNPUbTvQK7Ap+L0qD4Vp+sN434C+pdS3prVVlUfQdNeiEIgxox/kUQ==
 
 semver@^6.3.1:
   version "6.3.1"


### PR DESCRIPTION
## Problem

When user logs Vue instance of other big object with circular dependency, `safe-stringify` lead infinity.

## Solution

1. Use our Sanitizer module instead of `safe-stringify`
2. Sanitizer improved to support circular dips
3. Types updated to support consoleTracker add-on

