### PR TITLE
Configured per-package build on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,12 @@ jobs:
       CI_JOB_NUMBER: 2
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
       - run: corepack enable
       - run: yarn install
-      - run: yarn build
+      - run: yarn build:modified origin/${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - run: corepack enable
       - run: yarn
       - run: yarn lint-test
-      - run: yarn build
+      - run: yarn build:all
       - run: yarn workspace @hawk.so/javascript publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "dev": "yarn workspace @hawk.so/javascript dev",
-    "build": "yarn workspace @hawk.so/javascript build",
+    "build:all": "yarn workspaces foreach -Apt run build",
+    "build:modified": "yarn workspaces foreach --since=\"$@\" -Rpt run build",
     "stats": "yarn workspace @hawk.so/javascript stats",
     "lint": "eslint -c ./.eslintrc.cjs packages/*/src --ext .ts,.js --fix",
     "lint-test": "eslint -c ./.eslintrc.cjs packages/*/src --ext .ts,.js"


### PR DESCRIPTION
Closes #146 

This changes CI pipelines.

**On pull requests:**
- `build`
  - build only workspaces modified relative to the target branch

**On push to master**
- `publish`
  - lint `.ts`, `.js` files
  - build all workspaces
  - publish only `@hawk.so/javascript`