### PR TITLE
fix(js-catcher): allow optional context and set statusCode on fetch fail

### DIFF
--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.2.13",
+  "version": "3.2.14",
   "description": "JavaScript errors tracking for Hawk.so",
   "files": [
     "dist"

--- a/packages/javascript/src/addons/breadcrumbs.ts
+++ b/packages/javascript/src/addons/breadcrumbs.ts
@@ -403,6 +403,7 @@ export class BreadcrumbManager {
           data: {
             url,
             method,
+            statusCode: 0,
             durationMs: duration,
             error: error instanceof Error ? error.message : String(error),
           },

--- a/packages/javascript/src/utils/validation.ts
+++ b/packages/javascript/src/utils/validation.ts
@@ -30,7 +30,7 @@ export function validateUser(user: AffectedUser): boolean {
  * @param context
  */
 export function validateContext(context: EventContext | undefined): boolean {
-  if (!context || !Sanitizer.isObject(context)) {
+  if (context && !Sanitizer.isObject(context)) {
     log('validateContext: Context must be an object', 'warn');
 
     return false;


### PR DESCRIPTION
## Summary

Two small fixes in the JavaScript catcher:

1. **Validation — optional context**  
   `validateContext()` was treating missing/undefined context as invalid and logging "Context must be an object". Context is optional in `HawkInitialSettings` and in `setContext(context?: EventContext)`, so undefined should pass validation.  
   Updated the check to only fail when context is present but not an object (`context && !Sanitizer.isObject(context)`), so undefined is accepted.
![telegram-cloud-photo-size-2-5467629729184681731-y](https://github.com/user-attachments/assets/b4d9219e-1bb6-4a99-9cbe-d40cf45c5cbb)


2. **Breadcrumbs — fetch failure**  
   When a fetch request fails (e.g. network error), the breadcrumb in the catch block now explicitly sets `statusCode: 0` in `data`, so the UI can consistently treat failed requests (e.g. for coloring).
