### PR TITLE
Fix publishing script after yarn upgrade

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - run: yarn
       - run: yarn lint-test
       - run: yarn build:all
-      - run: yarn workspace @hawk.so/javascript publish --access=public
+      - run: yarn workspace @hawk.so/javascript npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   notify:


### PR DESCRIPTION
After upgrade yarn to 4.12.0 command `yarn workspace <workspace-name> npm publish` is no longer available.

Seems we should use `yarn workspace <workspace-name> npm publish` instead.

See actual [docs](https://yarnpkg.com/cli/npm/publish).