### PR TITLE
Fix env naming for publishing script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - run: yarn build:all
       - run: yarn workspace @hawk.so/javascript npm publish --access=public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   notify:
     needs: publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
On newer versions of yarn env variable for npm credentials is named `YARN_NPM_AUTH_TOKEN` instead of `NODE_AUTH_TOKEN`. This PR should fix this.