### PR TITLE
BaseCatcher abstraction added

### DIFF
--- a/packages/core/src/catcher.ts
+++ b/packages/core/src/catcher.ts
@@ -1,0 +1,458 @@
+import type {
+  AffectedUser,
+  BacktraceFrame,
+  CatcherMessage,
+  CatcherMessagePayload,
+  CatcherMessageType,
+  EncodedIntegrationToken,
+  EventContext
+} from '@hawk.so/types';
+import type { ErrorsCatcherType } from '@hawk.so/types/src/catchers/catcher-message';
+import type { Transport } from './utils/transport';
+import type { BreadcrumbStore } from './types/breadcrumb-store';
+import type { MessageProcessor, ProcessingPayload } from './types/message-processor';
+import { StackParser } from './features/stack-parser';
+import type { HawkUserManager } from './features/hawk-user-manager';
+import { validateContext, validateUser, isValidEventPayload } from './utils/validation';
+import { isErrorProcessed, markErrorAsProcessed } from './utils/event';
+import { Sanitizer } from './utils/sanitizer';
+import { log } from './utils/logger';
+
+/**
+ * User-supplied hook to filter or modify events before sending.
+ * - Return modified event — it will be sent instead of the original.
+ * - Return `false` — the event will be dropped entirely.
+ * - Any other value is invalid — the original event is sent as-is (a warning is logged).
+ *
+ * @typeParam T - catcher message type
+ */
+export type BeforeSendHook<T extends CatcherMessageType> = (event: CatcherMessagePayload<T>) => CatcherMessagePayload<T> | false | void;
+
+/**
+ * Abstract base class for all Hawk catchers.
+ *
+ * Contains env-agnostic logic for sending captured error events and managing related context.
+ *
+ * **Transport** — used to deliver assembled {@link CatcherMessage} objects to Collector.
+ * Provided via constructor.
+ *
+ * **User manager** — {@link HawkUserManager} resolves current affected user.
+ * Provided via constructor so each environment can supply its own storage backend.
+ *
+ * **Breadcrumb store** — optional {@link BreadcrumbStore} passed via constructor.
+ *
+ * **Message processors** — pipeline of {@link MessageProcessor} instances
+ * applied to every outgoing event. Environment-specific processors may be provided
+ * via {@link addMessageProcessor}.
+ *
+ * Each {@link formatAndSend} call initiates **sending pipeline** which consists of following steps:
+ * - base payload is built,
+ * - sequentially apply message processors to payload
+ * - apply optional {@link BeforeSendHook},
+ * - dispatch message via {@link Transport}.
+ *
+ * Subclasses must implement {@link getCatcherType} and {@link getCatcherVersion}
+ * (they are used for building base payload during sending pipeline).
+ *
+ * @typeParam T - catcher message type this catcher handles
+ */
+export abstract class BaseCatcher<T extends ErrorsCatcherType> {
+  /**
+   * Integration token used to identify the project
+   */
+  private readonly token: EncodedIntegrationToken;
+
+  /**
+   * Transport for dialog between Catcher and Collector
+   */
+  private readonly transport: Transport<T>;
+
+  /**
+   * Manages currently authenticated user identity
+   */
+  private readonly userManager: HawkUserManager;
+
+  /**
+   * Any additional data passed by user for sending with all messages
+   */
+  private context?: EventContext;
+
+  /**
+   * Current bundle version
+   */
+  private readonly release?: string;
+
+  /**
+   * This method allows developer to filter any data you don't want sending to Hawk.
+   * - Return modified event — it will be sent instead of the original.
+   * - Return `false` — the event will be dropped entirely.
+   * - Any other value is invalid — the original event is sent as-is (a warning is logged).
+   */
+  private readonly beforeSend?: BeforeSendHook<T>;
+
+  /**
+   * Breadcrumb store instance
+   */
+  private readonly breadcrumbStore?: BreadcrumbStore;
+
+  /**
+   * List of message processors applied to every outgoing event message.
+   */
+  private readonly messageProcessors: MessageProcessor<T>[] = [];
+
+  /**
+   * Module for parsing backtrace
+   */
+  private readonly stackParser: StackParser = new StackParser();
+
+  /**
+   * @param token - encoded integration token identifying the project
+   * @param transport - transport used to deliver events to Collector
+   * @param userManager - manages current affected user identity
+   * @param release - optional bundle release version attached to every event
+   * @param context - optional global context merged into every event
+   * @param beforeSend - optional hook to filter or modify events before sending
+   * @param breadcrumbStore - optional breadcrumb store
+   */
+  protected constructor(
+    token: EncodedIntegrationToken,
+    transport: Transport<T>,
+    userManager: HawkUserManager,
+    release?: string,
+    context?: EventContext,
+    beforeSend?: BeforeSendHook<T>,
+    breadcrumbStore?: BreadcrumbStore
+  ) {
+    this.token = token;
+    this.transport = transport;
+    this.userManager = userManager;
+    this.release = release;
+    this.beforeSend = beforeSend;
+    this.breadcrumbStore = breadcrumbStore;
+    this.setContext(context);
+  }
+
+  /**
+   * Send test event from client
+   */
+  public test(): void {
+    this.send(new Error('Hawk Catcher test message.'));
+  }
+
+  /**
+   * Public method for manual sending messages to the Hawk.
+   * Can be called in user's try-catch blocks or by other custom logic.
+   *
+   * @param message - what to send
+   * @param context - any additional data to send
+   */
+  public send(message: Error | string, context?: EventContext): void {
+    void this.formatAndSend(message, undefined, context);
+  }
+
+  /**
+   * Update the current user information
+   *
+   * @param user - New user information
+   */
+  public setUser(user: AffectedUser): void {
+    if (!validateUser(user)) {
+      return;
+    }
+
+    this.userManager.setUser(user);
+  }
+
+  /**
+   * Clear current user information
+   */
+  public clearUser(): void {
+    this.userManager.clear();
+  }
+
+  /**
+   * Update the context data that will be sent with all events
+   *
+   * @param context - New context data
+   */
+  public setContext(context: EventContext | undefined): void {
+    if (!validateContext(context)) {
+      return;
+    }
+
+    this.context = context;
+  }
+
+  /**
+   * Breadcrumbs API - provides convenient access to breadcrumb methods
+   *
+   * @example
+   * hawk.breadcrumbs.add({
+   *   type: 'user',
+   *   category: 'auth',
+   *   message: 'User logged in',
+   *   level: 'info',
+   *   data: { userId: '123' }
+   * });
+   */
+  public get breadcrumbs(): BreadcrumbStore {
+    return {
+      add: (breadcrumb, hint) => this.breadcrumbStore?.add(breadcrumb, hint),
+      get: () => this.breadcrumbStore?.get() ?? [],
+      clear: () => this.breadcrumbStore?.clear(),
+    };
+  }
+
+  /**
+   * Add message processor to the pipeline.
+   *
+   * @param processors - processors to add
+   */
+  protected addMessageProcessor(...processors: MessageProcessor<T>[]): void {
+    this.messageProcessors.push(...processors);
+  }
+
+  /**
+   * Process and sends error message.
+   *
+   * Returns early without sending if:
+   * - error was already processed,
+   * - a message processor drops it,
+   * - {@link beforeSend} hook rejects it.
+   *
+   * @param error - error to send
+   * @param integrationAddons - addons passed by integration (e.g. Vue, Nuxt)
+   * @param context - any additional data passed by user
+   */
+  protected async formatAndSend(
+    error: Error | string,
+    integrationAddons?: Record<string, unknown>,
+    context?: EventContext
+  ): Promise<void> {
+    try {
+      if (isErrorProcessed(error)) {
+        return;
+      }
+
+      markErrorAsProcessed(error);
+
+      let processingPayload = await this.buildBasePayload(error, context);
+
+      for (const processor of this.messageProcessors) {
+        const result = processor.apply(processingPayload, error);
+
+        if (result === null) {
+          // Event was dropped because a message processor returned null
+          return;
+        }
+
+        processingPayload = result;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = processingPayload as any as CatcherMessagePayload<T>;
+
+      if (integrationAddons) {
+        payload.addons = {
+          ...(payload.addons ?? {}),
+          ...Sanitizer.sanitize(integrationAddons),
+        };
+      }
+
+      const filtered = this.applyBeforeSendHook(payload);
+
+      if (filtered === null) {
+        return;
+      }
+
+      this.sendMessage({
+        token: this.token,
+        catcherType: this.getCatcherType(),
+        payload: filtered,
+      } as CatcherMessage<T>);
+    } catch (e) {
+      log('Unable to send error. Seems like it is Hawk internal bug. Please, report it here: https://github.com/codex-team/hawk.javascript/issues/new', 'warn', e);
+    }
+  }
+
+  /**
+   * Builds base event payload with core fields (title, type, backtrace, user, context, release).
+   *
+   * @param error - caught error or string reason
+   * @param context - per-call context to merge with instance-level context
+   * @returns base payload with core data
+   */
+  private async buildBasePayload(
+    error: Error | string,
+    context?: EventContext
+  ): Promise<ProcessingPayload<T>> {
+    return {
+      title: this.getTitle(error),
+      type: this.getType(error),
+      release: this.getRelease(),
+      context: this.getContext(context),
+      user: this.getUser(),
+      backtrace: await this.getBacktrace(error),
+      catcherVersion: this.getCatcherVersion(),
+      addons: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as ProcessingPayload<T>;
+  }
+
+  /**
+   * Clones payload and applies user-supplied {@link beforeSend} hook against it.
+   *
+   * @param payload - processed event message payload
+   * @returns possibly modified payload, or null if the event should be dropped
+   */
+  private applyBeforeSendHook(
+    payload: CatcherMessagePayload<T>
+  ): CatcherMessagePayload<T> | null {
+    if (typeof this.beforeSend !== 'function') {
+      return payload;
+    }
+
+    let clone: CatcherMessagePayload<T>;
+
+    try {
+      clone = structuredClone(payload);
+    } catch {
+      // structuredClone may fail on non-cloneable values (functions, DOM nodes, etc.)
+      // Fall back to passing the original — hook may mutate it, but at least reporting won't crash
+      clone = payload;
+    }
+
+    const result = this.beforeSend(clone);
+
+    // false → drop event
+    if (result === false) {
+      return null;
+    }
+
+    // Valid event payload → use it instead of original
+    if (isValidEventPayload(result)) {
+      return result as CatcherMessagePayload<T>;
+    }
+
+    // Anything else is invalid — warn, payload stays untouched (hook only received a clone)
+    log(
+      'Invalid beforeSend value. It should return event or false. Event is sent without changes.',
+      'warn'
+    );
+
+    return payload;
+  }
+
+  /**
+   * Dispatches assembled message over configured transport.
+   *
+   * @param message - fully assembled catcher message ready to send
+   */
+  private sendMessage(message: CatcherMessage<T>): void {
+    this.transport.send(message)
+      .catch((e) => log('Transport sending error', 'error', e));
+  }
+
+  /**
+   * Return event title.
+   *
+   * @param error - event from which to get the title
+   */
+  private getTitle(error: Error | string): string {
+    const notAnError = !(error instanceof Error);
+
+    // Case when error is 'reason' of PromiseRejectionEvent
+    // and reject() provided with text reason instead of Error()
+    if (notAnError) {
+      return error.toString();
+    }
+
+    return error.message;
+  }
+
+  /**
+   * Return event type: TypeError, ReferenceError etc.
+   *
+   * @param error - caught error
+   */
+  private getType(error: Error | string): string | undefined {
+    const notAnError = !(error instanceof Error);
+
+    // Case when error is 'reason' of PromiseRejectionEvent
+    // and reject() provided with text reason instead of Error()
+    if (notAnError) {
+      return undefined;
+    }
+
+    return error.name;
+  }
+
+  /**
+   * Release version
+   */
+  private getRelease(): string | undefined {
+    return this.release;
+  }
+
+  /**
+   * Collects additional information.
+   *
+   * @param context - any additional data passed by user
+   */
+  private getContext(context?: EventContext): EventContext | undefined {
+    const contextMerged = {};
+
+    if (this.context !== undefined) {
+      Object.assign(contextMerged, this.context);
+    }
+
+    if (context !== undefined) {
+      Object.assign(contextMerged, context);
+    }
+
+    return Sanitizer.sanitize(contextMerged);
+  }
+
+  /**
+   * Returns the current user if set, otherwise generates and persists an anonymous ID.
+   */
+  private getUser(): AffectedUser {
+    return this.userManager.getUser();
+  }
+
+  /**
+   * Return parsed backtrace information.
+   *
+   * @param error - event from which to get backtrace
+   */
+  private async getBacktrace(error: Error | string): Promise<BacktraceFrame[] | undefined> {
+    const notAnError = !(error instanceof Error);
+
+
+    // Case when error is 'reason' of PromiseRejectionEvent
+    // and reject() provided with text reason instead of Error()
+    if (notAnError) {
+      return undefined;
+    }
+
+    try {
+      return await this.stackParser.parse(error);
+    } catch (e) {
+      log('Can not parse stack:', 'warn', e);
+
+      return undefined;
+    }
+  }
+
+  /**
+   * Returns the catcher type identifier.
+   *
+   * @example 'errors/javascript'
+   */
+  protected abstract getCatcherType(): T;
+
+  /**
+   * Returns the catcher version string.
+   */
+  protected abstract getCatcherVersion(): string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,3 +13,6 @@ export { buildElementSelector } from './utils/selector';
 export { isErrorProcessed, markErrorAsProcessed } from './utils/event';
 export type { BreadcrumbStore, BreadcrumbsAPI, BreadcrumbHint, BreadcrumbInput } from './types/breadcrumb-store';
 export type { MessageProcessor, ProcessingPayload } from './types/message-processor';
+export { BaseCatcher } from './catcher';
+export type { BeforeSendHook } from './catcher';
+export { decodeIntegrationId } from './utils/integration-id-decoder';

--- a/packages/core/src/utils/integration-id-decoder.ts
+++ b/packages/core/src/utils/integration-id-decoder.ts
@@ -1,0 +1,33 @@
+import type { DecodedIntegrationToken, EncodedIntegrationToken } from '@hawk.so/types';
+
+/**
+ * Decodes and returns integration id from integration token.
+ * Also checks is integration ID valid.
+ *
+ * @param token - encoded integration token
+ */
+export function decodeIntegrationId(token: EncodedIntegrationToken): string {
+  const integrationId = decodeIntegrationToken(token);
+
+  if (!integrationId || integrationId === '') {
+    throw new Error('Invalid integration token.');
+  }
+
+  return integrationId;
+}
+
+/**
+ * Decodes and returns integration id from integration token.
+ *
+ * @param token - encoded integration token
+ */
+function decodeIntegrationToken(token: EncodedIntegrationToken): string {
+  try {
+    const decodedIntegrationToken: DecodedIntegrationToken = JSON.parse(atob(token));
+    const { integrationId } = decodedIntegrationToken;
+
+    return integrationId;
+  } catch {
+    throw new Error('Invalid integration token.');
+  }
+}

--- a/packages/core/tests/catcher.test.ts
+++ b/packages/core/tests/catcher.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { CatcherMessage, EventContext } from '@hawk.so/types';
+import { BaseCatcher, HawkUserManager } from '../src';
+import type {
+  BeforeSendHook,
+  Transport,
+  BreadcrumbStore,
+  BreadcrumbInput,
+  MessageProcessor,
+  HawkStorage,
+  RandomGenerator,
+} from '../src';
+
+vi.mock('../../src/utils/logger', () => ({
+  log: vi.fn(),
+  isLoggerSet: vi.fn(() => false),
+  setLogger: vi.fn(),
+  resetLogger: vi.fn(),
+}));
+
+type TestType = 'errors/javascript';
+
+class TestCatcher extends BaseCatcher<TestType> {
+  constructor(
+    token: string,
+    transport: Transport<TestType>,
+    userManager: HawkUserManager,
+    release?: string,
+    context?: EventContext,
+    beforeSend?: BeforeSendHook<TestType>,
+    breadcrumbStore?: BreadcrumbStore
+  ) {
+    super(token, transport, userManager, release, context, beforeSend, breadcrumbStore);
+  }
+
+  protected getCatcherType(): TestType {
+    return 'errors/javascript';
+  }
+
+  protected getCatcherVersion(): string {
+    return '0.0.0-test';
+  }
+
+  public async run(error: Error | string, integrationAddons?: Record<string, unknown>, context?: EventContext): Promise<void> {
+    return this.formatAndSend(error, integrationAddons, context);
+  }
+
+  public addProcessor(...processors: MessageProcessor<TestType>[]): void {
+    this.addMessageProcessor(...processors);
+  }
+}
+
+function makeUserManager(): HawkUserManager {
+  const storage: HawkStorage = {
+    getItem: vi.fn().mockReturnValue('anon-id'),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  };
+  const random: RandomGenerator = {
+    getRandomNumbers: vi.fn().mockReturnValue(new Uint8Array(40)),
+  };
+  return new HawkUserManager(storage, random);
+}
+
+function makeTransport() {
+  const send = vi.fn<[CatcherMessage<TestType>], Promise<void>>().mockResolvedValue(undefined);
+  return { send, transport: { send } as Transport<TestType> };
+}
+
+describe('BaseCatcher', () => {
+  describe('message processors', () => {
+    it('should not send event when a processor returns null', async () => {
+      const { send, transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager());
+
+      catcher.addProcessor({ apply: () => null });
+
+      await catcher.run(new Error('test'));
+
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('should stop pipeline at first null-returning processor and skip remaining ones', async () => {
+      const { send, transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager());
+      const secondProcessor: MessageProcessor<TestType> = { apply: vi.fn((p) => p) };
+
+      catcher.addProcessor({ apply: () => null }, secondProcessor);
+
+      await catcher.run(new Error('test'));
+
+      expect(send).not.toHaveBeenCalled();
+      expect(secondProcessor.apply).not.toHaveBeenCalled();
+    });
+
+    it('should send event when all processors pass the payload through', async () => {
+      const { send, transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager());
+
+      catcher.addProcessor({ apply: (p) => p }, { apply: (p) => p });
+
+      await catcher.run(new Error('test'));
+
+      expect(send).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('beforeSend hook', () => {
+    it('should drop event when beforeSend returns false', async () => {
+      const { send, transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager(), undefined, undefined, () => false);
+
+      await catcher.run(new Error('test'));
+
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('should send returned payload when beforeSend returns a valid modified event', async () => {
+      const { send, transport } = makeTransport();
+      const beforeSend: BeforeSendHook<TestType> = (event) => ({ ...event, title: 'replaced' });
+      const catcher = new TestCatcher('token', transport, makeUserManager(), undefined, undefined, beforeSend);
+
+      await catcher.run(new Error('original'));
+
+      expect(send).toHaveBeenCalledOnce();
+      expect(send.mock.calls[0][0].payload.title).toBe('replaced');
+    });
+
+    it('should send original event when beforeSend mutates the clone without returning', async () => {
+      const { send, transport } = makeTransport();
+      const beforeSend: BeforeSendHook<TestType> = (event) => {
+        event.title = 'mutated';
+        // no return — clone was mutated but original should be sent
+      };
+      const catcher = new TestCatcher('token', transport, makeUserManager(), undefined, undefined, beforeSend);
+
+      await catcher.run(new Error('original'));
+
+      expect(send).toHaveBeenCalledOnce();
+      expect(send.mock.calls[0][0].payload.title).toBe('original');
+    });
+
+    it('should send original event when beforeSend returns an invalid value', async () => {
+      const { send, transport } = makeTransport();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const beforeSend: BeforeSendHook<TestType> = () => 42 as any;
+      const catcher = new TestCatcher('token', transport, makeUserManager(), undefined, undefined, beforeSend);
+
+      await catcher.run(new Error('original'));
+
+      expect(send).toHaveBeenCalledOnce();
+      expect(send.mock.calls[0][0].payload.title).toBe('original');
+    });
+  });
+
+  describe('context merging', () => {
+    it('should include instance context when no per-call context is provided', async () => {
+      const { send, transport } = makeTransport();
+      const instanceContext = { env: 'production', version: '1' };
+      const catcher = new TestCatcher('token', transport, makeUserManager(), undefined, instanceContext);
+
+      await catcher.run(new Error('test'));
+
+      expect(send.mock.calls[0][0].payload.context).toEqual(instanceContext);
+    });
+
+    it('should let per-call context override instance context keys', async () => {
+      const { send, transport } = makeTransport();
+      const catcher = new TestCatcher(
+        'token', transport, makeUserManager(), undefined,
+        { env: 'production', version: '1' }
+      );
+
+      await catcher.run(new Error('test'), undefined, { version: '2', extra: 'data' });
+
+      expect(send.mock.calls[0][0].payload.context).toEqual({ env: 'production', version: '2', extra: 'data' });
+    });
+
+    it('should use only per-call context when no instance context is set', async () => {
+      const { send, transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager());
+
+      await catcher.run(new Error('test'), undefined, { requestId: 'abc' });
+
+      expect(send.mock.calls[0][0].payload.context).toEqual({ requestId: 'abc' });
+    });
+  });
+
+  describe('breadcrumbs', () => {
+    it('should delegate add() to the store', () => {
+      const store: BreadcrumbStore = { add: vi.fn(), get: vi.fn().mockReturnValue([]), clear: vi.fn() };
+      const { transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager(), undefined, undefined, undefined, store);
+      const crumb: BreadcrumbInput = { message: 'user clicked' };
+
+      catcher.breadcrumbs.add(crumb);
+
+      expect(store.add).toHaveBeenCalledWith(crumb, undefined);
+    });
+
+    it('should delegate get() to the store', () => {
+      const crumbs = [{ message: 'click', timestamp: 1000 }];
+      const store: BreadcrumbStore = { add: vi.fn(), get: vi.fn().mockReturnValue(crumbs), clear: vi.fn() };
+      const { transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager(), undefined, undefined, undefined, store);
+
+      expect(catcher.breadcrumbs.get()).toBe(crumbs);
+    });
+
+    it('should delegate clear() to the store', () => {
+      const store: BreadcrumbStore = { add: vi.fn(), get: vi.fn().mockReturnValue([]), clear: vi.fn() };
+      const { transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager(), undefined, undefined, undefined, store);
+
+      catcher.breadcrumbs.clear();
+
+      expect(store.clear).toHaveBeenCalledOnce();
+    });
+
+    it('should return empty array from get() when no store is configured', () => {
+      const { transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager());
+
+      expect(catcher.breadcrumbs.get()).toEqual([]);
+    });
+
+    it('should not throw when add() is called without a store', () => {
+      const { transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager());
+
+      expect(() => catcher.breadcrumbs.add({ message: 'test' })).not.toThrow();
+    });
+
+    it('should not throw when clear() is called without a store', () => {
+      const { transport } = makeTransport();
+      const catcher = new TestCatcher('token', transport, makeUserManager());
+
+      expect(() => catcher.breadcrumbs.clear()).not.toThrow();
+    });
+  });
+});

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "JavaScript errors tracking for Hawk.so",
   "files": [
     "dist"

--- a/packages/javascript/src/addons/browser-breadcrumbs-message-processor.ts
+++ b/packages/javascript/src/addons/browser-breadcrumbs-message-processor.ts
@@ -1,6 +1,6 @@
 import type { MessageProcessor, ProcessingPayload } from '@hawk.so/core';
-import type { BreadcrumbsOptions } from '../addons/breadcrumbs';
-import { BrowserBreadcrumbStore } from '../addons/breadcrumbs';
+import type { BreadcrumbsOptions } from './breadcrumbs';
+import { BrowserBreadcrumbStore } from './breadcrumbs';
 import type { ErrorsCatcherType } from '@hawk.so/types/src/catchers/catcher-message';
 
 /**

--- a/packages/javascript/src/addons/console-output-addon-message-processor.ts
+++ b/packages/javascript/src/addons/console-output-addon-message-processor.ts
@@ -1,5 +1,5 @@
 import type { MessageProcessor, ProcessingPayload } from '@hawk.so/core';
-import type { ConsoleCatcher } from '../addons/consoleCatcher';
+import type { ConsoleCatcher } from './consoleCatcher';
 
 /**
  * Attaches captured console output to payload addons.

--- a/packages/javascript/src/catcher.ts
+++ b/packages/javascript/src/catcher.ts
@@ -1,34 +1,13 @@
 import './modules/element-sanitizer';
 import Socket from './modules/socket';
-import type { CatcherMessage, HawkInitialSettings, HawkJavaScriptEvent, Transport } from './types';
+import type { HawkInitialSettings } from './types';
 import { isPerformanceIssueDetectorEnabled } from './types/issues';
 import { VueIntegration } from './integrations/vue';
-import type {
-  AffectedUser,
-  CatcherMessagePayload,
-  DecodedIntegrationToken,
-  EncodedIntegrationToken,
-  EventContext,
-  VueIntegrationAddons
-} from '@hawk.so/types';
+import type { VueIntegrationAddons } from '@hawk.so/types';
 import type { JavaScriptCatcherIntegrations } from '@/types';
 import { ConsoleCatcher } from './addons/consoleCatcher';
 import { BrowserBreadcrumbStore } from './addons/breadcrumbs';
-import type { BreadcrumbStore, MessageProcessor, ProcessingPayload } from '@hawk.so/core';
-import { PerformanceIssuesMonitor } from './addons/performance-issues';
-import {
-  HawkUserManager,
-  isErrorProcessed,
-  isLoggerSet,
-  isValidEventPayload,
-  log,
-  markErrorAsProcessed,
-  Sanitizer,
-  setLogger,
-  StackParser,
-  validateContext,
-  validateUser
-} from '@hawk.so/core';
+import { BaseCatcher, HawkUserManager, isLoggerSet, log, setLogger, decodeIntegrationId } from '@hawk.so/core';
 import { HawkLocalStorage } from './utils/hawk-local-storage';
 import { createBrowserLogger } from './utils/logger';
 import { BrowserRandomGenerator } from './utils/random';
@@ -36,6 +15,7 @@ import { BrowserAddonMessageProcessor } from './addons/browser-addon-message-pro
 import { ConsoleOutputAddonMessageProcessor } from './addons/console-output-addon-message-processor';
 import { DebugAddonMessageProcessor } from './addons/debug-addon-message-processor';
 import { BrowserBreadcrumbsMessageProcessor } from './addons/browser-breadcrumbs-message-processor';
+import { PerformanceIssuesMonitor } from './addons/performance-issues';
 
 /**
  * Allow to use global VERSION, that will be overwritten by Webpack
@@ -55,7 +35,7 @@ if (!isLoggerSet()) {
  *
  * @copyright CodeX
  */
-export default class Catcher {
+export default class Catcher extends BaseCatcher<typeof Catcher.type> {
   /**
    * JS Catcher version
    */
@@ -72,43 +52,9 @@ export default class Catcher {
   private static readonly type = 'errors/javascript' as const;
 
   /**
-   * User project's Integration Token
-   */
-  private readonly token: EncodedIntegrationToken;
-
-  /**
    * Enable debug mode
    */
   private readonly debug: boolean;
-
-  /**
-   * Current bundle version
-   */
-  private readonly release: string | undefined;
-
-  /**
-   * Any additional data passed by user for sending with all messages
-   */
-  private context: EventContext | undefined;
-
-  /**
-   * This Method allows developer to filter any data you don't want sending to Hawk.
-   * - Return modified event — it will be sent instead of the original.
-   * - Return `false` — the event will be dropped entirely.
-   * - Any other value is invalid — the original event is sent as-is (a warning is logged).
-   */
-  private readonly beforeSend: undefined | ((event: HawkJavaScriptEvent<typeof Catcher.type>) => HawkJavaScriptEvent<typeof Catcher.type> | false | void);
-
-  /**
-   * Transport for dialog between Catcher and Collector
-   * (WebSocket decorator by default, or custom via settings.transport)
-   */
-  private readonly transport: Transport<typeof Catcher.type>;
-
-  /**
-   * Module for parsing backtrace
-   */
-  private readonly stackParser: StackParser = new StackParser();
 
   /**
    * Disable Vue.js error handler
@@ -126,27 +72,9 @@ export default class Catcher {
   private readonly consoleCatcher: ConsoleCatcher | null = null;
 
   /**
-   * Breadcrumb store instance
-   */
-  private readonly breadcrumbStore: BrowserBreadcrumbStore | null = null;
-
-  /**
    * Issues monitor instance
    */
   private issuesMonitor: PerformanceIssuesMonitor | null = null;
-
-  /**
-   * Manages currently authenticated user identity.
-   */
-  private readonly userManager: HawkUserManager = new HawkUserManager(
-    new HawkLocalStorage(),
-    new BrowserRandomGenerator()
-  );
-
-  /**
-   * Ordered list of message processors applied to every outgoing event message.
-   */
-  private readonly messageProcessors: MessageProcessor<typeof Catcher.type>[];
 
   /**
    * Catcher constructor
@@ -160,14 +88,50 @@ export default class Catcher {
       } as HawkInitialSettings;
     }
 
-    this.token = settings.token;
+    const token = settings.token;
+    const userManager = new HawkUserManager(
+      new HawkLocalStorage(),
+      new BrowserRandomGenerator()
+    );
+    /**
+     * Init transport
+     * WebSocket decorator by default, or custom via {@link settings.transport}
+     * No-op when token is missing
+     */
+    const transport = !token
+      ? { send: (): Promise<void> => Promise.resolve() }
+      : settings.transport ?? new Socket({
+        collectorEndpoint: settings.collectorEndpoint || `wss://${decodeIntegrationId(token)}.k1.hawk.so:443/ws`,
+        reconnectionAttempts: settings.reconnectionAttempts,
+        reconnectionTimeout: settings.reconnectionTimeout,
+        onClose(): void {
+          log(
+            'Connection lost. Connection will be restored when new errors occurred',
+            'info'
+          );
+        },
+      });
+
+    let breadcrumbStore: BrowserBreadcrumbStore | null = null;
+
+    if (token && settings.breadcrumbs !== false) {
+      breadcrumbStore = BrowserBreadcrumbStore.getInstance();
+    }
+
+    super(
+      token,
+      transport,
+      userManager,
+      settings.release !== undefined ? String(settings.release) : undefined,
+      settings.context || undefined,
+      settings.beforeSend,
+      breadcrumbStore ?? undefined
+    );
+
     this.debug = settings.debug || false;
-    this.release = settings.release !== undefined ? String(settings.release) : undefined;
     if (settings.user) {
       this.setUser(settings.user);
     }
-    this.setContext(settings.context || undefined);
-    this.beforeSend = settings.beforeSend;
     this.disableVueErrorHandler =
       settings.disableVueErrorHandler !== null && settings.disableVueErrorHandler !== undefined
         ? settings.disableVueErrorHandler
@@ -176,11 +140,9 @@ export default class Catcher {
       settings.consoleTracking !== null && settings.consoleTracking !== undefined
         ? settings.consoleTracking
         : true;
-    this.messageProcessors = [
-      new BrowserAddonMessageProcessor(),
-    ];
 
-    if (!this.token) {
+
+    if (!token) {
       log(
         'Integration Token is missed. You can get it on https://hawk.so at Project Settings.',
         'warn'
@@ -189,36 +151,20 @@ export default class Catcher {
       return;
     }
 
-    /**
-     * Init transport
-     */
-    this.transport = settings.transport ?? new Socket({
-      collectorEndpoint: settings.collectorEndpoint || `wss://${this.getIntegrationId()}.k1.hawk.so:443/ws`,
-      reconnectionAttempts: settings.reconnectionAttempts,
-      reconnectionTimeout: settings.reconnectionTimeout,
-      onClose(): void {
-        log(
-          'Connection lost. Connection will be restored when new errors occurred',
-          'info'
-        );
-      },
-    });
+    this.addMessageProcessor(new BrowserAddonMessageProcessor());
 
     if (this.consoleTracking) {
       this.consoleCatcher = ConsoleCatcher.getInstance();
-      this.messageProcessors.push(new ConsoleOutputAddonMessageProcessor(this.consoleCatcher));
+      this.addMessageProcessor(new ConsoleOutputAddonMessageProcessor(this.consoleCatcher));
     }
 
-    /**
-     * Initialize breadcrumbs
-     */
+    // Initialize breadcrumbs
     if (settings.breadcrumbs !== false) {
-      this.breadcrumbStore = BrowserBreadcrumbStore.getInstance();
-      this.messageProcessors.push(new BrowserBreadcrumbsMessageProcessor(settings.breadcrumbs ?? {}));
+      this.addMessageProcessor(new BrowserBreadcrumbsMessageProcessor(settings.breadcrumbs ?? {}));
     }
 
     if (this.debug) {
-      this.messageProcessors.push(new DebugAddonMessageProcessor());
+      this.addMessageProcessor(new DebugAddonMessageProcessor());
     }
 
     this.configureIssues(settings);
@@ -229,31 +175,11 @@ export default class Catcher {
   }
 
   /**
-   * Send test event from client
-   */
-  public test(): void {
-    const fakeEvent = new Error('Hawk JavaScript Catcher test message.');
-
-    this.send(fakeEvent);
-  }
-
-  /**
-   * Public method for manual sending messages to the Hawk
-   * Can be called in user's try-catch blocks or by other custom logic
-   *
-   * @param message - what to send
-   * @param [context] - any additional data to send
-   */
-  public send(message: Error | string, context?: EventContext): void {
-    void this.formatAndSend(message, undefined, context);
-  }
-
-  /**
    * Method for Frameworks SDK using own error handlers.
    * Allows to send errors to Hawk with additional Frameworks data (addons)
    *
    * @param error - error to send
-   * @param [addons] - framework-specific data, can be undefined
+   * @param addons - framework-specific data, can be undefined
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public captureError(error: Error | string, addons?: JavaScriptCatcherIntegrations): void {
@@ -281,56 +207,17 @@ export default class Catcher {
   }
 
   /**
-   * Update the current user information
-   *
-   * @param user - New user information
+   * Returns {@link Catcher.type}
    */
-  public setUser(user: AffectedUser): void {
-    if (!validateUser(user)) {
-      return;
-    }
-
-    this.userManager.setUser(user);
+  protected getCatcherType(): typeof Catcher.type {
+    return Catcher.type;
   }
 
   /**
-   * Clear current user information
+   * Returns catcher version
    */
-  public clearUser(): void {
-    this.userManager.clear();
-  }
-
-  /**
-   * Breadcrumbs API - provides convenient access to breadcrumb methods
-   *
-   * @example
-   * hawk.breadcrumbs.add({
-   *   type: 'user',
-   *   category: 'auth',
-   *   message: 'User logged in',
-   *   level: 'info',
-   *   data: { userId: '123' }
-   * });
-   */
-  public get breadcrumbs(): BreadcrumbStore {
-    return {
-      add: (breadcrumb, hint) => this.breadcrumbStore?.add(breadcrumb, hint),
-      get: () => this.breadcrumbStore?.get() ?? [],
-      clear: () => this.breadcrumbStore?.clear(),
-    };
-  }
-
-  /**
-   * Update the context data that will be sent with all events
-   *
-   * @param context - New context data
-   */
-  public setContext(context: EventContext | undefined): void {
-    if (!validateContext(context)) {
-      return;
-    }
-
-    this.context = context;
+  protected getCatcherVersion(): string {
+    return VERSION;
   }
 
   /**
@@ -377,14 +264,10 @@ export default class Catcher {
    * @param {ErrorEvent|PromiseRejectionEvent} event — (!) both for Error and Promise Rejection
    */
   private async handleEvent(event: ErrorEvent | PromiseRejectionEvent): Promise<void> {
-    /**
-     * Add error to console logs
-     */
-
+    // Add error to console logs
     if (this.consoleTracking) {
       this.consoleCatcher!.addErrorEvent(event);
     }
-
     /**
      * Promise rejection reason is recommended to be an Error, but it can be a string:
      * - Promise.reject(new Error('Reason message')) ——— recommended
@@ -402,264 +285,5 @@ export default class Catcher {
     }
 
     void this.formatAndSend(error);
-  }
-
-  /**
-   * Process and sends error message.
-   *
-   * Returns early without sending either if
-   * - error was already processed,
-   * - message processor drops it
-   * - {@link beforeSend} hook rejects it
-   *
-   * @param error - error to send
-   * @param integrationAddons - addons spoiled by Integration
-   * @param context - any additional data passed by user
-   */
-  private async formatAndSend(
-    error: Error | string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    integrationAddons?: JavaScriptCatcherIntegrations,
-    context?: EventContext
-  ): Promise<void> {
-    try {
-      const isAlreadySentError = isErrorProcessed(error);
-
-      if (isAlreadySentError) {
-        /**
-         * @todo add debug build and log this case
-         */
-        return;
-      } else {
-        markErrorAsProcessed(error);
-      }
-
-      let processingPayload = await this.buildBasePayload(error, context);
-
-      for (const processor of this.messageProcessors) {
-        const result = processor.apply(processingPayload, error);
-
-        if (result === null) {
-          return;
-        }
-
-        processingPayload = result;
-      }
-
-      const payload = processingPayload as CatcherMessagePayload<typeof Catcher.type>;
-
-      if (integrationAddons) {
-        payload.addons = {
-          ...(payload.addons ?? {}),
-          ...Sanitizer.sanitize(integrationAddons),
-        };
-      }
-
-      const payloadPostBeforeSend = this.applyBeforeSendHook(payload);
-
-      if (payloadPostBeforeSend === null) {
-        // Event was rejected by user using the beforeSend method
-        return;
-      }
-
-      this.sendMessage({
-        token: this.token,
-        catcherType: Catcher.type,
-        payload: payloadPostBeforeSend,
-      } as CatcherMessage<typeof Catcher.type>);
-    } catch (e) {
-      log('Unable to send error. Seems like it is Hawk internal bug. Please, report it here: https://github.com/codex-team/hawk.javascript/issues/new', 'warn', e);
-    }
-  }
-
-  /**
-   * Builds base event payload with basic fields (title, type, backtrace, user, context, release).
-   *
-   * @param error - caught error or string reason
-   * @param context - per-call context to merge with instance-level context
-   * @returns base payload with core data
-   */
-  private async buildBasePayload(
-    error: Error | string,
-    context?: EventContext
-  ): Promise<ProcessingPayload<typeof Catcher.type>> {
-    return {
-      title: this.getTitle(error),
-      type: this.getType(error),
-      release: this.getRelease(),
-      context: this.getContext(context),
-      user: this.getUser(),
-      backtrace: await this.getBacktrace(error),
-      catcherVersion: this.version,
-      addons: {},
-    };
-  }
-
-  /**
-   * Clones {@link payload} and applies user-supplied {@link beforeSend} hook against it.
-   *
-   * @param payload - processed event message payload
-   * @returns possibly modified payload, or null if the event should be dropped
-   */
-  private applyBeforeSendHook(
-    payload: CatcherMessagePayload<typeof Catcher.type>
-  ): CatcherMessagePayload<typeof Catcher.type> | null {
-    if (typeof this.beforeSend !== 'function') {
-      return payload;
-    }
-
-    let clone: CatcherMessagePayload<typeof Catcher.type>;
-
-    try {
-      clone = structuredClone(payload);
-    } catch {
-      // structuredClone may fail on non-cloneable values (functions, DOM nodes, etc.)
-      // Fall back to passing the original — hook may mutate it, but at least reporting won't crash
-      clone = payload;
-    }
-
-    const result = this.beforeSend(clone);
-
-    // false → drop event
-    if (result === false) {
-      return null;
-    }
-
-    // Valid event payload → use it instead of original
-    if (isValidEventPayload(result)) {
-      return result as CatcherMessagePayload<typeof Catcher.type>;
-    }
-
-    // Anything else is invalid — warn, payload stays untouched (hook only received a clone)
-    log(
-      'Invalid beforeSend value. It should return event or false. Event is sent without changes.',
-      'warn'
-    );
-
-    return payload;
-  }
-
-  /**
-   * Dispatches assembled message over configured transport.
-   *
-   * @param message - fully assembled catcher message ready to send
-   */
-  private sendMessage(message: CatcherMessage<typeof Catcher.type>): void {
-    this.transport.send(message)
-      .catch((e) => log('Transport sending error', 'error', e));
-  }
-
-  /**
-   * Return event title
-   *
-   * @param error - event from which to get the title
-   */
-  private getTitle(error: Error | string): string {
-    const notAnError = !(error instanceof Error);
-
-    /**
-     * Case when error is 'reason' of PromiseRejectionEvent
-     * and reject() provided with text reason instead of Error()
-     */
-    if (notAnError) {
-      return error.toString() as string;
-    }
-
-    return (error as Error).message;
-  }
-
-  /**
-   * Return event type: TypeError, ReferenceError etc
-   *
-   * @param error - caught error
-   */
-  private getType(error: Error | string): HawkJavaScriptEvent['type'] {
-    const notAnError = !(error instanceof Error);
-
-    /**
-     * Case when error is 'reason' of PromiseRejectionEvent
-     * and reject() provided with text reason instead of Error()
-     */
-    if (notAnError) {
-      return undefined;
-    }
-
-    return (error as Error).name;
-  }
-
-  /**
-   * Release version
-   */
-  private getRelease(): HawkJavaScriptEvent['release'] {
-    return this.release !== undefined ? String(this.release) : undefined;
-  }
-
-  /**
-   * Returns integration id from integration token
-   */
-  private getIntegrationId(): string {
-    try {
-      const decodedIntegrationToken: DecodedIntegrationToken = JSON.parse(atob(this.token));
-      const { integrationId } = decodedIntegrationToken;
-
-      if (!integrationId || integrationId === '') {
-        throw new Error();
-      }
-
-      return integrationId;
-    } catch {
-      throw new Error('Invalid integration token.');
-    }
-  }
-
-  /**
-   * Collects additional information
-   *
-   * @param context - any additional data passed by user
-   */
-  private getContext(context?: EventContext): HawkJavaScriptEvent['context'] {
-    const contextMerged = {};
-
-    if (this.context !== undefined) {
-      Object.assign(contextMerged, this.context);
-    }
-
-    if (context !== undefined) {
-      Object.assign(contextMerged, context);
-    }
-
-    return Sanitizer.sanitize(contextMerged);
-  }
-
-  /**
-   * Returns the current user if set, otherwise generates and persists an anonymous ID.
-   */
-  private getUser(): AffectedUser {
-    return this.userManager.getUser();
-  }
-
-  /**
-   * Return parsed backtrace information
-   *
-   * @param error - event from which to get backtrace
-   */
-  private async getBacktrace(error: Error | string): Promise<HawkJavaScriptEvent['backtrace']> {
-    const notAnError = !(error instanceof Error);
-
-    /**
-     * Case when error is 'reason' of PromiseRejectionEvent
-     * and reject() provided with text reason instead of Error()
-     */
-    if (notAnError) {
-      return undefined;
-    }
-
-    try {
-      return await this.stackParser.parse(error as Error);
-    } catch (e) {
-      log('Can not parse stack:', 'warn', e);
-
-      return undefined;
-    }
   }
 }

--- a/packages/javascript/src/types/issues.ts
+++ b/packages/javascript/src/types/issues.ts
@@ -46,6 +46,8 @@ export interface PerformanceIssuesOptions {
 /**
  * Whether a performance detector is explicitly enabled (`true` or a non-empty options object).
  * `undefined` means off (default).
+ *
+ * @param option - performance detector option value (`true`, options object, `false`, or `undefined`).
  */
 export function isPerformanceIssueDetectorEnabled(
   option: boolean | PerformanceIssueThresholdOptions | WebVitalOptions | undefined

--- a/packages/javascript/tests/catcher.test.ts
+++ b/packages/javascript/tests/catcher.test.ts
@@ -135,7 +135,7 @@ describe('Catcher', () => {
       await wait();
 
       expect(sendSpy).toHaveBeenCalledOnce();
-      expect(getLastPayload(sendSpy).title).toContain('Hawk JavaScript Catcher test message');
+      expect(getLastPayload(sendSpy).title).toContain('Hawk Catcher test message');
     });
   });
 


### PR DESCRIPTION
Closes #151 

Env-agnostic logic from Catcher in `@hawk.so/javascript` moved in new abstract `BaseCatcher` in `@hawk.so/core` so general logic (breadcrumbs management, user management, context management, message pre-processing and sending, and other utilities) may be reused in other platform-specific implementations.

Browser-specific logic (UI-framework integrations, window event listeners, `ConsoleCatcher`) remain in original `Catcher` in `@hawk.so/javascript`.