### PR TITLE
Extract sanitizer module

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,4 +4,5 @@ export { HawkUserManager } from './users/hawk-user-manager';
 export type { Logger, LogType } from './logger/logger';
 export { isLoggerSet, setLogger, resetLogger, log } from './logger/logger';
 export { validateUser, validateContext, isValidEventPayload, isValidBreadcrumb } from './utils/validation';
-export { isPlainObject } from './utils/type-guards';
+export { isPlainObject, isArray, isClassPrototype, isClassInstance, isString } from './utils/type-guards';
+export { Sanitizer } from './modules/sanitizer';

--- a/packages/core/src/modules/sanitizer.ts
+++ b/packages/core/src/modules/sanitizer.ts
@@ -1,12 +1,32 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { isArray, isClassInstance, isClassPrototype, isPlainObject, isString } from '../utils/type-guards';
+
+/**
+ * Custom type handler for Sanitizer.
+ *
+ * Allows user to register their own formatters from external packages.
+ */
+export interface SanitizerTypeHandler {
+  /**
+   * Checks if this handler should be applied to given value
+   *
+   * @returns `true`
+   */
+  check: (target: any) => boolean;
+
+  /**
+   * Formats the value into a sanitized representation
+   */
+  format: (target: any) => any;
+}
+
 /**
  * This class provides methods for preparing data to sending to Hawk
  * - trim long strings
- * - represent html elements like <div ...> as "<div>" instead of "{}"
  * - represent big objects as "<big object>"
  * - represent class as <class SomeClass> or <instance of SomeClass>
  */
-export default class Sanitizer {
+export class Sanitizer {
   /**
    * Maximum string length
    */
@@ -29,12 +49,21 @@ export default class Sanitizer {
   private static readonly maxArrayLength: number = 10;
 
   /**
-   * Check if passed variable is an object
+   * Custom type handlers registered via {@link registerHandler}.
    *
-   * @param target - variable to check
+   * Checked in {@link sanitize} before built-in type checks.
    */
-  public static isObject(target: any): boolean {
-    return Sanitizer.typeOf(target) === 'object';
+  private static readonly customHandlers: SanitizerTypeHandler[] = [];
+
+  /**
+   * Register a custom type handler.
+   * Handlers are checked before built-in type checks, in reverse registration order
+   * (last registered = highest priority).
+   *
+   * @param handler - handler to register
+   */
+  public static registerHandler(handler: SanitizerTypeHandler): void {
+    Sanitizer.customHandlers.unshift(handler);
   }
 
   /**
@@ -45,9 +74,7 @@ export default class Sanitizer {
    * @param seen - Set of already seen objects to prevent circular references
    */
   public static sanitize(data: any, depth = 0, seen = new WeakSet<object>()): any {
-    /**
-     * Check for circular references on objects and arrays
-     */
+    // Check for circular references on objects and arrays
     if (data !== null && typeof data === 'object') {
       if (seen.has(data)) {
         return '<circular>';
@@ -55,49 +82,42 @@ export default class Sanitizer {
       seen.add(data);
     }
 
-    /**
-     * If value is an Array, apply sanitizing for each element
-     */
-    if (Sanitizer.isArray(data)) {
+    // If value is an Array, apply sanitizing for each element
+    if (isArray(data)) {
       return this.sanitizeArray(data, depth + 1, seen);
+    }
 
-      /**
-       * If value is an Element, format it as string with outer HTML
-       * HTMLDivElement -> "<div ...></div>"
-       */
-    } else if (Sanitizer.isElement(data)) {
-      return Sanitizer.formatElement(data);
+    // Check additional handlers provided by env-specific modules or users
+    // to sanitize some additional cases (e.g. specific object types)
+    for (const handler of Sanitizer.customHandlers) {
+      if (handler.check(data)) {
+        return handler.format(data);
+      }
+    }
 
-      /**
-       * If values is a not-constructed class, it will be formatted as "<class SomeClass>"
-       * class Editor {...} -> <class Editor>
-       */
-    } else if (Sanitizer.isClassPrototype(data)) {
+    // If values is a not-constructed class, it will be formatted as "<class SomeClass>"
+    // class Editor {...} -> <class Editor>
+    if (isClassPrototype(data)) {
       return Sanitizer.formatClassPrototype(data);
+    }
 
-      /**
-       * If values is a some class instance, it will be formatted as "<instance of SomeClass>"
-       * new Editor() -> <instance of Editor>
-       */
-    } else if (Sanitizer.isClassInstance(data)) {
+    // If values is a some class instance, it will be formatted as "<instance of SomeClass>"
+    // new Editor() -> <instance of Editor>
+    if (isClassInstance(data)) {
       return Sanitizer.formatClassInstance(data);
+    }
 
-      /**
-       * If values is an object, do recursive call
-       */
-    } else if (Sanitizer.isObject(data)) {
+    // If values is an object, do recursive call
+    if (isPlainObject(data)) {
       return Sanitizer.sanitizeObject(data, depth + 1, seen);
+    }
 
-      /**
-       * If values is a string, trim it for max-length
-       */
-    } else if (Sanitizer.isString(data)) {
+    // If values is a string, trim it for max-length
+    if (isString(data)) {
       return Sanitizer.trimString(data);
     }
 
-    /**
-     * If values is a number, boolean and other primitive, leave as is
-     */
+    // If values is a number, boolean and other primitive, leave as is
     return data;
   }
 
@@ -109,9 +129,7 @@ export default class Sanitizer {
    * @param seen - Set of already seen objects to prevent circular references
    */
   private static sanitizeArray(arr: any[], depth: number, seen: WeakSet<object>): any[] {
-    /**
-     * If the maximum length is reached, slice array to max length and add a placeholder
-     */
+    // If the maximum length is reached, slice array to max length and add a placeholder
     const length = arr.length;
 
     if (length > Sanitizer.maxArrayLength) {
@@ -131,17 +149,18 @@ export default class Sanitizer {
    * @param depth - current depth of recursion
    * @param seen - Set of already seen objects to prevent circular references
    */
-  private static sanitizeObject(data: { [key: string]: any }, depth: number, seen: WeakSet<object>): Record<string, any> | '<deep object>' | '<big object>' {
-    /**
-     * If the maximum depth is reached, return a placeholder
-     */
+  private static sanitizeObject(
+    data: { [key: string]: any },
+    depth: number,
+    seen: WeakSet<object>
+  ): Record<string, any> | '<deep object>' | '<big object>' {
+
+    // If the maximum depth is reached, return a placeholder
     if (depth > Sanitizer.maxDepth) {
       return '<deep object>';
     }
 
-    /**
-     * If the object has more keys than the limit, return a placeholder
-     */
+    // If the object has more keys than the limit, return a placeholder
     if (Object.keys(data).length > Sanitizer.maxObjectKeysCount) {
       return '<big object>';
     }
@@ -155,72 +174,6 @@ export default class Sanitizer {
     }
 
     return result;
-  }
-
-  /**
-   * Check if passed variable is an array
-   *
-   * @param target - variable to check
-   */
-  private static isArray(target: any): boolean {
-    return Array.isArray(target);
-  }
-
-  /**
-   * Check if passed variable is a not-constructed class
-   *
-   * @param target - variable to check
-   */
-  private static isClassPrototype(target: any): boolean {
-    if (!target || !target.constructor) {
-      return false;
-    }
-
-    /**
-     * like
-     * "function Function {
-     *   [native code]
-     * }"
-     */
-    const constructorStr = target.constructor.toString();
-
-    return constructorStr.includes('[native code]') && constructorStr.includes('Function');
-  }
-
-  /**
-   * Check if passed variable is a constructed class instance
-   *
-   * @param target - variable to check
-   */
-  private static isClassInstance(target: any): boolean {
-    return target && target.constructor && (/^class \S+ {/).test(target.constructor.toString());
-  }
-
-  /**
-   * Check if passed variable is a string
-   *
-   * @param target - variable to check
-   */
-  private static isString(target: any): boolean {
-    return typeof target === 'string';
-  }
-
-  /**
-   * Return string representation of the object type
-   *
-   * @param object - object to get type
-   */
-  private static typeOf(object: any): string {
-    return Object.prototype.toString.call(object).match(/\s([a-zA-Z]+)/)[1].toLowerCase();
-  }
-
-  /**
-   * Check if passed variable is an HTML Element
-   *
-   * @param target - variable to check
-   */
-  private static isElement(target: any): boolean {
-    return target instanceof Element;
   }
 
   /**
@@ -248,29 +201,10 @@ export default class Sanitizer {
    */
   private static trimString(target: string): string {
     if (target.length > Sanitizer.maxStringLen) {
-      return target.substr(0, Sanitizer.maxStringLen) + '…';
+      return target.substring(0, Sanitizer.maxStringLen) + '…';
     }
 
     return target;
-  }
-
-  /**
-   * Represent HTML Element as string with it outer-html
-   * HTMLDivElement -> "<div ...></div>"
-   *
-   * @param target - variable to format
-   */
-  private static formatElement(target: Element): string {
-    /**
-     * Also, remove inner HTML because it can be BIG
-     */
-    const innerHTML = target.innerHTML;
-
-    if (innerHTML) {
-      return target.outerHTML.replace(target.innerHTML, '…');
-    }
-
-    return target.outerHTML;
   }
 
   /**

--- a/packages/core/src/utils/type-guards.ts
+++ b/packages/core/src/utils/type-guards.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * Checks if value is a plain object (not null, array, Date, Map, etc.)
  *
@@ -11,4 +13,56 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
   const proto = Object.getPrototypeOf(value);
 
   return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Check if passed variable is an array
+ *
+ * @param value - variable to check
+ * @returns `true` if value is an array, otherwise `false`
+ */
+export function isArray(value: any): value is any[] {
+  return Array.isArray(value);
+}
+
+/**
+ * Check if passed variable is a not-constructed class
+ *
+ * @param value - variable to check
+ * @returns `true` if value is a class prototype, otherwise `false`
+ */
+export function isClassPrototype(value: any): boolean {
+  if (!value || !value.constructor) {
+    return false;
+  }
+
+  /**
+   * like
+   * "function Function {
+   *   [native code]
+   * }"
+   */
+  const constructorStr = value.constructor.toString();
+
+  return constructorStr.includes('[native code]') && constructorStr.includes('Function');
+}
+
+/**
+ * Check if passed variable is a constructed class instance
+ *
+ * @param value - variable to check
+ * @returns `true` if value is a class instance, otherwise `false`
+ */
+export function isClassInstance(value: any): boolean {
+  return !!(value && value.constructor && (/^class \S+ {/).test(value.constructor.toString()));
+}
+
+/**
+ * Check if passed variable is a string
+ *
+ * @param value - variable to check
+ * @returns `true` if value is a string, otherwise `false`
+ */
+export function isString(value: any): value is string {
+  return typeof value === 'string';
 }

--- a/packages/core/tests/modules/sanitizer.test.ts
+++ b/packages/core/tests/modules/sanitizer.test.ts
@@ -1,33 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import Sanitizer from '../../src/modules/sanitizer';
+import { describe, expect, it } from 'vitest';
+import { Sanitizer } from '../../src';
 
 describe('Sanitizer', () => {
-  describe('isObject', () => {
-    it('should return true for a plain object', () => {
-      expect(Sanitizer.isObject({})).toBe(true);
-    });
-
-    it('should return false for an array', () => {
-      expect(Sanitizer.isObject([])).toBe(false);
-    });
-
-    it('should return false for a string', () => {
-      expect(Sanitizer.isObject('x')).toBe(false);
-    });
-
-    it('should return false for a boolean', () => {
-      expect(Sanitizer.isObject(true)).toBe(false);
-    });
-
-    it('should return false for null', () => {
-      expect(Sanitizer.isObject(null)).toBe(false);
-    });
-
-    it('should return false for undefined', () => {
-      expect(Sanitizer.isObject(undefined)).toBe(false);
-    });
-  });
-
   describe('sanitize', () => {
     it('should pass through strings within the length limit', () => {
       expect(Sanitizer.sanitize('hello')).toBe('hello');
@@ -83,14 +57,6 @@ describe('Sanitizer', () => {
       const result = Sanitizer.sanitize(deep);
 
       expect(result.a.b.c.d.e).toBe('<deep object>');
-    });
-
-    it('should format HTML elements as a string starting with tag', () => {
-      const el = document.createElement('div');
-      const result = Sanitizer.sanitize(el);
-
-      expect(typeof result).toBe('string');
-      expect(result).toMatch(/^<div/);
     });
 
     it('should format a class (not constructed) as "<class Name>"', () => {

--- a/packages/core/tests/utils/type-guards.test.ts
+++ b/packages/core/tests/utils/type-guards.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isPlainObject } from '../../src';
+import { isArray, isClassInstance, isClassPrototype, isPlainObject, isString } from '../../src';
 
 class Foo {}
 const fooInstance = new Foo();
@@ -15,4 +15,54 @@ describe('isPlainObject', () => {
   it('should return false for undefined', () => expect(isPlainObject(undefined)).toBe(false));
   it('should return false for class prototype', () => expect(isPlainObject(Foo)).toBe(false));
   it('should return false for class instance', () => expect(isPlainObject(fooInstance)).toBe(false));
+});
+
+describe('isArray', () => {
+  it('should return true for empty array', () => expect(isArray([])).toBe(true));
+  it('should return true for non-empty array', () => expect(isArray([1, 2, 3])).toBe(true));
+  it('should return false for plain object', () => expect(isArray({})).toBe(false));
+  it('should return false for string', () => expect(isArray('hello')).toBe(false));
+  it('should return false for number', () => expect(isArray(42)).toBe(false));
+  it('should return false for boolean', () => expect(isArray(true)).toBe(false));
+  it('should return false for null', () => expect(isArray(null)).toBe(false));
+  it('should return false for undefined', () => expect(isArray(undefined)).toBe(false));
+  it('should return false for class prototype', () => expect(isArray(Foo)).toBe(false));
+  it('should return false for class instance', () => expect(isArray(fooInstance)).toBe(false));
+});
+
+describe('isClassPrototype', () => {
+  it('should return true for class prototype', () => expect(isClassPrototype(Foo)).toBe(true));
+  it('should return false for class instance', () => expect(isClassPrototype(fooInstance)).toBe(false));
+  it('should return false for plain object', () => expect(isClassPrototype({})).toBe(false));
+  it('should return false for array', () => expect(isClassPrototype([])).toBe(false));
+  it('should return false for string', () => expect(isClassPrototype('foo')).toBe(false));
+  it('should return false for number', () => expect(isClassPrototype(42)).toBe(false));
+  it('should return false for boolean', () => expect(isClassPrototype(true)).toBe(false));
+  it('should return false for null', () => expect(isClassPrototype(null)).toBe(false));
+  it('should return false for undefined', () => expect(isClassPrototype(undefined)).toBe(false));
+});
+
+describe('isClassInstance', () => {
+  it('should return true for class instance', () => expect(isClassInstance(fooInstance)).toBe(true));
+  it('should return false for class prototype', () => expect(isClassInstance(Foo)).toBe(false));
+  it('should return false for plain object', () => expect(isClassInstance({})).toBe(false));
+  it('should return false for array', () => expect(isClassInstance([])).toBe(false));
+  it('should return false for string', () => expect(isClassInstance('foo')).toBe(false));
+  it('should return false for number', () => expect(isClassInstance(42)).toBe(false));
+  it('should return false for boolean', () => expect(isClassInstance(true)).toBe(false));
+  it('should return false for null', () => expect(isClassInstance(null)).toBe(false));
+  it('should return false for undefined', () => expect(isClassInstance(undefined)).toBe(false));
+});
+
+describe('isString', () => {
+  it('should return true for string', () => expect(isString('hello')).toBe(true));
+  it('should return true for empty string', () => expect(isString('')).toBe(true));
+  it('should return false for plain object', () => expect(isString({})).toBe(false));
+  it('should return false for array', () => expect(isString([])).toBe(false));
+  it('should return false for number', () => expect(isString(42)).toBe(false));
+  it('should return false for boolean', () => expect(isString(true)).toBe(false));
+  it('should return false for null', () => expect(isString(null)).toBe(false));
+  it('should return false for undefined', () => expect(isString(undefined)).toBe(false));
+  it('should return false for class prototype', () => expect(isString(Foo)).toBe(false));
+  it('should return false for class instance', () => expect(isString(fooInstance)).toBe(false));
 });

--- a/packages/javascript/src/addons/breadcrumbs.ts
+++ b/packages/javascript/src/addons/breadcrumbs.ts
@@ -2,9 +2,8 @@
  * @file Breadcrumbs module - captures chronological trail of events before an error
  */
 import type { Breadcrumb, BreadcrumbLevel, BreadcrumbType, Json, JsonNode } from '@hawk.so/types';
-import Sanitizer from '../modules/sanitizer';
+import { isValidBreadcrumb, log, Sanitizer } from '@hawk.so/core';
 import { buildElementSelector } from '../utils/selector';
-import { isValidBreadcrumb, log } from '@hawk.so/core';
 
 /**
  * Default maximum number of breadcrumbs to store

--- a/packages/javascript/src/addons/consoleCatcher.ts
+++ b/packages/javascript/src/addons/consoleCatcher.ts
@@ -2,7 +2,7 @@
  * @file Module for intercepting console logs with stack trace capture
  */
 import type { ConsoleLogEvent } from '@hawk.so/types';
-import Sanitizer from '../modules/sanitizer';
+import { Sanitizer } from '@hawk.so/core';
 
 /**
  * Maximum number of console logs to store

--- a/packages/javascript/src/catcher.ts
+++ b/packages/javascript/src/catcher.ts
@@ -1,5 +1,5 @@
+import './modules/element-sanitizer';
 import Socket from './modules/socket';
-import Sanitizer from './modules/sanitizer';
 import StackParser from './modules/stackParser';
 import type { BreadcrumbsAPI, CatcherMessage, HawkInitialSettings, HawkJavaScriptEvent, Transport } from './types';
 import { VueIntegration } from './integrations/vue';
@@ -18,8 +18,16 @@ import { isErrorProcessed, markErrorAsProcessed } from './utils/event';
 import { BrowserRandomGenerator } from './utils/random';
 import { ConsoleCatcher } from './addons/consoleCatcher';
 import { BreadcrumbManager } from './addons/breadcrumbs';
-import { isValidEventPayload, validateContext, validateUser } from '@hawk.so/core';
-import { HawkUserManager, isLoggerSet, log, setLogger } from '@hawk.so/core';
+import {
+  HawkUserManager,
+  isLoggerSet,
+  isValidEventPayload,
+  log,
+  Sanitizer,
+  setLogger,
+  validateContext,
+  validateUser
+} from '@hawk.so/core';
 import { HawkLocalStorage } from './storages/hawk-local-storage';
 import { createBrowserLogger } from './logger/logger';
 

--- a/packages/javascript/src/modules/element-sanitizer.ts
+++ b/packages/javascript/src/modules/element-sanitizer.ts
@@ -1,0 +1,20 @@
+import { Sanitizer } from '@hawk.so/core';
+
+/**
+ * Registers browser-specific sanitizer handler for {@link Element} objects.
+ *
+ * Handles HTML Element and represents as string with it outer HTML with
+ * inner content replaced: HTMLDivElement -> "<div ...></div>"
+ */
+Sanitizer.registerHandler({
+  check: (target) => target instanceof Element,
+  format: (target: Element) => {
+    const innerHTML = target.innerHTML;
+
+    if (innerHTML) {
+      return target.outerHTML.replace(target.innerHTML, '…');
+    }
+
+    return target.outerHTML;
+  },
+});

--- a/packages/javascript/tests/modules/element-sanitizer.test.ts
+++ b/packages/javascript/tests/modules/element-sanitizer.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { Sanitizer } from '@hawk.so/core';
+import '../../src/modules/element-sanitizer';
+
+describe('Browser Sanitizer handlers', () => {
+  describe('Element handler', () => {
+    it('should format an empty HTML element as its outer HTML', () => {
+      const el = document.createElement('div');
+      const result = Sanitizer.sanitize(el);
+
+      expect(typeof result).toBe('string');
+      expect(result).toMatch(/^<div/);
+    });
+
+    it('should replace inner HTML content with ellipsis', () => {
+      const el = document.createElement('div');
+
+      el.innerHTML = '<span>some long content</span>';
+
+      const result = Sanitizer.sanitize(el);
+
+      expect(result).toContain('…');
+      expect(result).not.toContain('some long content');
+    });
+  });
+});


### PR DESCRIPTION
- `Sanitizer` moved to `@hawk.so/core` (except `Element` handling since it depends on `jsdom`)
- `Sanitizer.isPlainObject` removed (use function from `type-guards.ts`)
- type guard private methods moved to `type-guards.ts` as public functions
- `SanitizerTypeHandler` feature added
-  `SanitizerTypeHandler` for browser `Element` added