### PR TITLE
Extracted transport interface

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,4 @@ export { isLoggerSet, setLogger, resetLogger, log } from './logger/logger';
 export { validateUser, validateContext, isValidEventPayload, isValidBreadcrumb } from './utils/validation';
 export { isPlainObject, isArray, isClassPrototype, isClassInstance, isString } from './utils/type-guards';
 export { Sanitizer } from './modules/sanitizer';
+export type { Transport } from './transports/transport';

--- a/packages/core/src/transports/transport.ts
+++ b/packages/core/src/transports/transport.ts
@@ -1,0 +1,8 @@
+import type { CatcherMessage, CatcherMessageType } from '@hawk.so/types';
+
+/**
+ * Transport interface — anything that can send a CatcherMessage
+ */
+export interface Transport<T extends CatcherMessageType = 'errors/javascript'> {
+  send(message: CatcherMessage<T>): Promise<void>;
+}

--- a/packages/javascript/src/catcher.ts
+++ b/packages/javascript/src/catcher.ts
@@ -63,7 +63,7 @@ export default class Catcher {
   /**
    * Catcher Type
    */
-  private readonly type: string = 'errors/javascript';
+  private static readonly type = 'errors/javascript' as const;
 
   /**
    * User project's Integration Token
@@ -91,13 +91,13 @@ export default class Catcher {
    * - Return `false` — the event will be dropped entirely.
    * - Any other value is invalid — the original event is sent as-is (a warning is logged).
    */
-  private readonly beforeSend: undefined | ((event: HawkJavaScriptEvent) => HawkJavaScriptEvent | false | void);
+  private readonly beforeSend: undefined | ((event: HawkJavaScriptEvent<typeof Catcher.type>) => HawkJavaScriptEvent<typeof Catcher.type> | false | void);
 
   /**
    * Transport for dialog between Catcher and Collector
    * (WebSocket decorator by default, or custom via settings.transport)
    */
-  private readonly transport: Transport;
+  private readonly transport: Transport<typeof Catcher.type>;
 
   /**
    * Module for parsing backtrace
@@ -410,7 +410,7 @@ export default class Catcher {
    *
    * @param errorFormatted - formatted error to send
    */
-  private sendErrorFormatted(errorFormatted: CatcherMessage): void {
+  private sendErrorFormatted(errorFormatted: CatcherMessage<typeof Catcher.type>): void {
     this.transport.send(errorFormatted)
       .catch((sendingError) => {
         log('WebSocket sending error', 'error', sendingError);
@@ -423,7 +423,7 @@ export default class Catcher {
    * @param error - error to format
    * @param context - any additional data passed by user
    */
-  private async prepareErrorFormatted(error: Error | string, context?: EventContext): Promise<CatcherMessage> {
+  private async prepareErrorFormatted(error: Error | string, context?: EventContext): Promise<CatcherMessage<typeof Catcher.type>> {
     let payload: HawkJavaScriptEvent = {
       title: this.getTitle(error),
       type: this.getType(error),
@@ -479,7 +479,7 @@ export default class Catcher {
 
     return {
       token: this.token,
-      catcherType: this.type,
+      catcherType: Catcher.type,
       payload,
     };
   }
@@ -516,7 +516,7 @@ export default class Catcher {
      * and reject() provided with text reason instead of Error()
      */
     if (notAnError) {
-      return null;
+      return undefined;
     }
 
     return (error as Error).name;
@@ -526,7 +526,7 @@ export default class Catcher {
    * Release version
    */
   private getRelease(): HawkJavaScriptEvent['release'] {
-    return this.release !== undefined ? String(this.release) : null;
+    return this.release !== undefined ? String(this.release) : undefined;
   }
 
   /**
@@ -579,7 +579,7 @@ export default class Catcher {
   private getBreadcrumbsForEvent(): HawkJavaScriptEvent['breadcrumbs'] {
     const breadcrumbs = this.breadcrumbManager?.getBreadcrumbs();
 
-    return breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : null;
+    return breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs : undefined;
   }
 
   /**
@@ -619,7 +619,7 @@ export default class Catcher {
      * and reject() provided with text reason instead of Error()
      */
     if (notAnError) {
-      return null;
+      return undefined;
     }
 
     try {
@@ -627,7 +627,7 @@ export default class Catcher {
     } catch (e) {
       log('Can not parse stack:', 'warn', e);
 
-      return null;
+      return undefined;
     }
   }
 
@@ -693,7 +693,7 @@ export default class Catcher {
    * @param errorFormatted - Hawk event prepared for sending
    * @param integrationAddons - extra addons
    */
-  private appendIntegrationAddons(errorFormatted: CatcherMessage, integrationAddons: JavaScriptCatcherIntegrations): void {
-    Object.assign(errorFormatted.payload.addons, integrationAddons);
+  private appendIntegrationAddons(errorFormatted: CatcherMessage<typeof Catcher.type>, integrationAddons: JavaScriptCatcherIntegrations): void {
+    Object.assign(errorFormatted.payload.addons!, integrationAddons);
   }
 }

--- a/packages/javascript/src/modules/socket.ts
+++ b/packages/javascript/src/modules/socket.ts
@@ -1,13 +1,14 @@
+import type { Transport } from '@hawk.so/core';
 import { log } from '@hawk.so/core';
 import type { CatcherMessage } from '@/types';
-import type { Transport } from '../types/transport';
+import type { CatcherMessageType } from '@hawk.so/types';
 
 /**
  * Custom WebSocket wrapper class
  *
  * @copyright CodeX
  */
-export default class Socket implements Transport {
+export default class Socket<T extends CatcherMessageType = 'errors/javascript'> implements Transport<T> {
   /**
    * Socket connection endpoint
    */
@@ -32,7 +33,7 @@ export default class Socket implements Transport {
    * Queue of events collected while socket is not connected
    * They will be sent when connection will be established
    */
-  private eventsQueue: CatcherMessage[];
+  private eventsQueue: CatcherMessage<T>[];
 
   /**
    * Websocket instance
@@ -106,7 +107,7 @@ export default class Socket implements Transport {
    *
    * @param message - event data in Hawk Format
    */
-  public async send(message: CatcherMessage): Promise<void> {
+  public async send(message: CatcherMessage<T>): Promise<void> {
     if (this.ws === null) {
       this.eventsQueue.push(message);
 

--- a/packages/javascript/src/types/catcher-message.ts
+++ b/packages/javascript/src/types/catcher-message.ts
@@ -1,21 +1,7 @@
-import type { HawkJavaScriptEvent } from './event';
+import type { CatcherMessage as HawkCatcherMessage } from '@hawk.so/types';
+import type { CatcherMessageType } from '@hawk.so/types/src/catchers/catcher-message';
 
 /**
  * Structure describing a message sending by Catcher
  */
-export interface CatcherMessage {
-  /**
-   * User project's Integration Token
-   */
-  token: string;
-
-  /**
-   * Hawk Catcher name
-   */
-  catcherType: string;
-
-  /**
-   * All information about the event
-   */
-  payload: HawkJavaScriptEvent;
-}
+export type CatcherMessage<T extends CatcherMessageType = 'errors/javascript'> = HawkCatcherMessage<T>;

--- a/packages/javascript/src/types/event.ts
+++ b/packages/javascript/src/types/event.ts
@@ -1,55 +1,7 @@
-import type { AffectedUser, BacktraceFrame, EventContext, EventData, JavaScriptAddons, Breadcrumb } from '@hawk.so/types';
-
-/**
- * Event data with JS specific addons
- */
-type JSEventData = EventData<JavaScriptAddons>;
+import type { CatcherMessagePayload } from '@hawk.so/types';
+import type { ErrorsCatcherType } from '@hawk.so/types/src/catchers/catcher-message';
 
 /**
  * Event will be sent to Hawk by Hawk JavaScript SDK
- *
- * The listed EventData properties will always be sent, so we define them as required in the type
  */
-export type HawkJavaScriptEvent = Omit<JSEventData, 'type' | 'release' | 'breadcrumbs' | 'user' | 'context' | 'addons' | 'backtrace' | 'catcherVersion'> & {
-  /**
-   * Event type: TypeError, ReferenceError etc
-   * null for non-error events
-   */
-  type: string | null;
-
-  /**
-   * Current release (aka version, revision) of an application
-   */
-  release: string | null;
-
-  /**
-   * Breadcrumbs - chronological trail of events before the error
-   */
-  breadcrumbs: Breadcrumb[] | null;
-
-  /**
-   * Current authenticated user
-   */
-  user: AffectedUser | null;
-
-  /**
-   * Any other information collected and passed by user
-   */
-  context: EventContext;
-
-  /**
-   * Catcher-specific information
-   */
-  addons: JavaScriptAddons;
-
-  /**
-   * Stack
-   * From the latest call to the earliest
-   */
-  backtrace: BacktraceFrame[] | null;
-
-  /**
-   * Catcher version
-   */
-  catcherVersion: string;
-};
+export type HawkJavaScriptEvent<T extends ErrorsCatcherType = 'errors/javascript'> = CatcherMessagePayload<T>;

--- a/packages/javascript/src/types/index.ts
+++ b/packages/javascript/src/types/index.ts
@@ -1,6 +1,6 @@
 import type { CatcherMessage } from './catcher-message';
 import type { HawkInitialSettings } from './hawk-initial-settings';
-import type { Transport } from './transport';
+import type { Transport } from '@hawk.so/core';
 import type { HawkJavaScriptEvent } from './event';
 import type { VueIntegrationData, NuxtIntegrationData, NuxtIntegrationAddons, JavaScriptCatcherIntegrations } from './integrations';
 import type { BreadcrumbsAPI } from './breadcrumbs-api';

--- a/packages/javascript/src/types/transport.ts
+++ b/packages/javascript/src/types/transport.ts
@@ -1,8 +1,0 @@
-import type { CatcherMessage } from './catcher-message';
-
-/**
- * Transport interface — anything that can send a CatcherMessage
- */
-export interface Transport {
-  send(message: CatcherMessage): Promise<void>;
-}


### PR DESCRIPTION
- `CatcherMessage` replaced with `CatcherMessage` from `@hawk.so/types`
- `HawkJavaScriptEvent` replaced with `CatcherMessagePayload` from `@hawk.so/types`
- interface `Transport` moved to `@hawk.so/core`
- interface `Transport` now has type-parameter `CatcherMessageType` with `'errors/javascript'` as default type