### PR TITLE
chore: resolve workspace cross-dependencies from source

### DIFF
--- a/packages/javascript/vite.config.ts
+++ b/packages/javascript/vite.config.ts
@@ -26,7 +26,6 @@ export default defineConfig(() => {
         fileName: 'hawk',
       },
       rollupOptions: {
-        external: ['@hawk.so/core'],
         plugins: [
           license({
             thirdParty: {
@@ -37,8 +36,8 @@ export default defineConfig(() => {
                     return false;
                   }
 
-                  // Allow MIT and Apache-2.0 licenses.
-                  return ['MIT', 'Apache-2.0'].includes(dependency.license);
+                  // Allow MIT, Apache-2.0, and AGPL-3.0-only (first-party @hawk.so packages).
+                  return ['MIT', 'Apache-2.0', 'AGPL-3.0-only'].includes(dependency.license);
                 },
                 failOnUnlicensed: true,
                 failOnViolation: true,
@@ -56,6 +55,7 @@ export default defineConfig(() => {
     },
 
     resolve: {
+      conditions: ['source'],
       alias: {
         '@/types': path.resolve(__dirname, './src/types'),
       },

--- a/packages/sveltekit/playground/vite.config.ts
+++ b/packages/sveltekit/playground/vite.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
   server: {
     host: true,
   },
+  resolve: {
+    conditions: ['source'],
+  },
 });

--- a/packages/sveltekit/vite.config.ts
+++ b/packages/sveltekit/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig(() => {
         external: ['sveltekit', '@hawk.so/javascript'],
       },
     },
+    resolve: {
+      conditions: ['source'],
+    },
     plugins: [
       dts({
         tsconfigPath: './tsconfig.json',


### PR DESCRIPTION
Closes #173

## Summary

- Add `resolve.conditions: ['source']`  to `packages/javascript` vite and vitest configs, and `packages/sveltekit` vite config — so Vite/Vitest resolve cross-workspace imports from TypeScript source instead of `dist/`
- Bundle `@hawk.so/core` into `@hawk.so/javascript` output instead of externalizing it (core is not published to npm separately yet)
- Add `AGPL-3.0-only` to the license allow list in `rollup-plugin-license` since core shares the same license

## Result

`build:modified` and `test:modified` now work from a clean checkout with no pre-built `dist/` in any workspace.