### PR TITLE
Suppress StackParser to extract source code from files during tests

### DIFF
--- a/packages/javascript/tests/catcher.addons.test.ts
+++ b/packages/javascript/tests/catcher.addons.test.ts
@@ -3,9 +3,10 @@ import { BreadcrumbManager } from '../src/addons/breadcrumbs';
 import { wait, createTransport, getLastPayload, createCatcher } from './catcher.helpers';
 
 const mockParse = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-vi.mock('../src/modules/stackParser', () => ({
-  default: class { parse = mockParse; },
-}));
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = mockParse; } };
+});
 
 describe('Catcher', () => {
   beforeEach(() => {

--- a/packages/javascript/tests/catcher.before-send.test.ts
+++ b/packages/javascript/tests/catcher.before-send.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createCatcher, createTransport, wait, getLastPayload } from './catcher.helpers';
 
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = vi.fn().mockResolvedValue([]); } };
+});
+
 describe('Catcher', () => {
   it('should send event as-is when beforeSend returns it unchanged', async () => {
     const { sendSpy, transport } = createTransport();

--- a/packages/javascript/tests/catcher.breadcrumbs.test.ts
+++ b/packages/javascript/tests/catcher.breadcrumbs.test.ts
@@ -3,9 +3,10 @@ import { BreadcrumbManager } from '../src/addons/breadcrumbs';
 import { wait, createTransport, getLastPayload, createCatcher } from './catcher.helpers';
 
 const mockParse = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-vi.mock('../src/modules/stackParser', () => ({
-  default: class { parse = mockParse; },
-}));
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = mockParse; } };
+});
 
 describe('Catcher', () => {
   beforeEach(() => {

--- a/packages/javascript/tests/catcher.context.test.ts
+++ b/packages/javascript/tests/catcher.context.test.ts
@@ -3,9 +3,10 @@ import { BreadcrumbManager } from '../src/addons/breadcrumbs';
 import { wait, createTransport, getLastPayload, createCatcher } from './catcher.helpers';
 
 const mockParse = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-vi.mock('../src/modules/stackParser', () => ({
-  default: class { parse = mockParse; },
-}));
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = mockParse; } };
+});
 
 describe('Catcher', () => {
   beforeEach(() => {

--- a/packages/javascript/tests/catcher.global-handlers.test.ts
+++ b/packages/javascript/tests/catcher.global-handlers.test.ts
@@ -4,9 +4,10 @@ import { BreadcrumbManager } from '../src/addons/breadcrumbs';
 import { TEST_TOKEN, wait, createTransport, getLastPayload } from './catcher.helpers';
 
 const mockParse = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-vi.mock('../src/modules/stackParser', () => ({
-  default: class { parse = mockParse; },
-}));
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = mockParse; } };
+});
 
 describe('Catcher', () => {
   beforeEach(() => {

--- a/packages/javascript/tests/catcher.release.test.ts
+++ b/packages/javascript/tests/catcher.release.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createCatcher, createTransport, getLastPayload, wait } from "./catcher.helpers";
+
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = vi.fn().mockResolvedValue([]); } };
+});
 
 describe('Catcher', () => {
   it('should include release version when configured', async () => {

--- a/packages/javascript/tests/catcher.test.ts
+++ b/packages/javascript/tests/catcher.test.ts
@@ -5,11 +5,10 @@ import { TEST_TOKEN, wait, createTransport, getLastPayload, createCatcher } from
 
 // StackParser is mocked to prevent real network calls to source files in the jsdom environment.
 const mockParse = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-vi.mock('../src/modules/stackParser', () => ({
-  default: class {
-    parse = mockParse;
-  },
-}));
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = mockParse; } };
+});
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 

--- a/packages/javascript/tests/catcher.transport.test.ts
+++ b/packages/javascript/tests/catcher.transport.test.ts
@@ -4,9 +4,10 @@ import type { Transport } from '../src';
 import { wait, createCatcher, createTransport } from './catcher.helpers';
 
 const mockParse = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-vi.mock('../src/modules/stackParser', () => ({
-  default: class { parse = mockParse; },
-}));
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = mockParse; } };
+});
 
 describe('Catcher', () => {
   beforeEach(() => {

--- a/packages/javascript/tests/catcher.user.test.ts
+++ b/packages/javascript/tests/catcher.user.test.ts
@@ -3,9 +3,10 @@ import { BreadcrumbManager } from '../src/addons/breadcrumbs';
 import { wait, createTransport, getLastPayload, createCatcher } from './catcher.helpers';
 
 const mockParse = vi.hoisted(() => vi.fn().mockResolvedValue([]));
-vi.mock('../src/modules/stackParser', () => ({
-  default: class { parse = mockParse; },
-}));
+vi.mock('@hawk.so/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hawk.so/core')>();
+  return { ...actual, StackParser: class { parse = mockParse; } };
+});
 
 describe('Catcher', () => {
   beforeEach(() => {


### PR DESCRIPTION
Catcher read backtrace from file file via `StackParser`.

In most test-cases we don't have this file, still `StackParser` tries to find it, fails and output spam logs:

```
[@hawk.so/javascript]: Hawk JS SDK: Can not extract source code. Please, report this issue: https://github.com/codex-team/hawk.javascript/issues/new TypeError: fetch failed
[@hawk.so/javascript]:     at node:internal/deps/undici/undici:15845:13
[@hawk.so/javascript]:     at window.fetch (/home/reversean/Dev/codex/hawk.javascript/packages/javascript/src/addons/breadcrumbs.ts:398:20) {
[@hawk.so/javascript]:   [cause]: Error: not implemented... yet...
[@hawk.so/javascript]:       at makeNetworkError (node:internal/deps/undici/undici:10147:35)
[@hawk.so/javascript]:       at schemeFetch (node:internal/deps/undici/undici:11685:34)
[@hawk.so/javascript]:       at mainFetch (node:internal/deps/undici/undici:11533:30)
[@hawk.so/javascript]:       at fetching (node:internal/deps/undici/undici:11502:7)
[@hawk.so/javascript]:       at fetch (node:internal/deps/undici/undici:11368:20)
[@hawk.so/javascript]:       at fetch (node:internal/deps/undici/undici:15843:10)
[@hawk.so/javascript]:       at fetch (node:internal/bootstrap/web/exposed-window-or-worker:83:12)
[@hawk.so/javascript]:       at window.fetch (/home/reversean/Dev/codex/hawk.javascript/packages/javascript/src/addons/breadcrumbs.ts:398:26)
[@hawk.so/javascript]:       at fetchTimer (/home/reversean/Dev/codex/hawk.javascript/packages/core/src/modules/fetch-timer.ts:19:24)
[@hawk.so/javascript]:       at StackParser.loadSourceFile (/home/reversean/Dev/codex/hawk.javascript/packages/core/src/modules/stack-parser.ts:133:41)
[@hawk.so/javascript]: }
```

Suggested changes mocks `StackParser.parse` in catcher tests which prevents trash unwanted logs.