### PR TITLE
Add @hawk.so/core to npm publish 

### DIFF
--- a/.github/workflows/bump-package.yml
+++ b/.github/workflows/bump-package.yml
@@ -1,0 +1,65 @@
+name: Bump package version
+
+on:
+  workflow_call:
+    inputs:
+      workspace:
+        required: true
+        type: string
+        description: 'Yarn workspace name'
+      path:
+        required: true
+        type: string
+        description: 'Package directory relative to repo root'
+
+jobs:
+  bump:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Check if package was modified and version needs bump
+        id: check
+        run: |
+          # Exit cleanly if the package directory was not touched in this PR
+          if git diff --quiet ${{ github.event.pull_request.base.sha }} HEAD -- ${{ inputs.path }}; then
+            echo "No changes detected in ${{ inputs.path }}."
+            echo "should-bump=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Compare old (base) and new (HEAD) version strings
+          OLD_VERSION=$(git show ${{ github.event.pull_request.base.sha }}:${{ inputs.path }}/package.json | jq -r '.version')
+          NEW_VERSION=$(jq -r '.version' ${{ inputs.path }}/package.json)
+
+          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+            echo "Version already bumped by developer ($OLD_VERSION → $NEW_VERSION)."
+            echo "should-bump=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "should-bump=true" >> $GITHUB_OUTPUT
+
+      - uses: actions/setup-node@v4
+        if: steps.check.outputs.should-bump == 'true'
+        with:
+          node-version-file: '.nvmrc'
+
+      - run: corepack enable
+        if: steps.check.outputs.should-bump == 'true'
+
+      - name: Bump ${{ inputs.workspace }} version
+        if: steps.check.outputs.should-bump == 'true'
+        run: yarn workspace ${{ inputs.workspace }} version patch
+
+      - uses: EndBug/add-and-commit@v9
+        if: steps.check.outputs.should-bump == 'true'
+        with:
+          author_name: github-actions
+          author_email: 41898282+github-actions[bot]@users.noreply.github.com
+          message: 'chore: bump ${{ inputs.workspace }} version'
+          pull: '--rebase --autostash'

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,16 @@
+name: Bump version in PR
+
+on: [pull_request]
+
+jobs:
+  bump-version-core:
+    uses: ./.github/workflows/bump-package.yml
+    with:
+      workspace: '@hawk.so/core'
+      path: packages/core
+
+  bump-version-javascript:
+    uses: ./.github/workflows/bump-package.yml
+    with:
+      workspace: '@hawk.so/javascript'
+      path: packages/javascript

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -19,6 +19,9 @@ jobs:
       - run: yarn
       - run: yarn lint-test
       - run: yarn build:all
+      - run: yarn workspace @hawk.so/core npm publish --access=public
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: yarn workspace @hawk.so/javascript npm publish --access=public
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -26,7 +29,7 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get package info
         id: package
         uses: codex-team/action-nodejs-package-info@v1

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "JavaScript errors tracking for Hawk.so",
   "files": [
     "dist"
@@ -40,11 +40,11 @@
   },
   "homepage": "https://github.com/codex-team/hawk.javascript#readme",
   "dependencies": {
+    "@hawk.so/core": "workspace:^",
     "error-stack-parser": "^2.1.4",
     "web-vitals": "^5.1.0"
   },
   "devDependencies": {
-    "@hawk.so/core": "workspace:^",
     "@hawk.so/types": "0.5.8",
     "@vitest/coverage-v8": "^4.0.18",
     "jsdom": "^28.0.0",


### PR DESCRIPTION
Extends the CI publish workflow to publish `@hawk.so/core` to npm alongside `@hawk.so/javascript`. 

Also bumps `actions/checkout` from `v2` to `v4` in both workflow jobs.

Also moves `@hawk.so/core` from a dev dependency to a runtime dependency in `@hawk.so/javascript` (see #180).