### PR TITLE
Fixed socket usage

### DIFF
--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "JavaScript errors tracking for Hawk.so",
   "files": [
     "dist"

--- a/packages/javascript/src/catcher.ts
+++ b/packages/javascript/src/catcher.ts
@@ -102,8 +102,7 @@ export default class Catcher extends BaseCatcher<typeof Catcher.type> {
       ? { send: (): Promise<void> => Promise.resolve() }
       : settings.transport ?? new Socket({
         collectorEndpoint: settings.collectorEndpoint || `wss://${decodeIntegrationId(token)}.k1.hawk.so:443/ws`,
-        reconnectionAttempts: settings.reconnectionAttempts,
-        reconnectionTimeout: settings.reconnectionTimeout,
+        connectionIdleMs: settings.reconnectionTimeout,
         onClose(): void {
           log(
             'Connection lost. Connection will be restored when new errors occurred',

--- a/packages/javascript/src/types/hawk-initial-settings.ts
+++ b/packages/javascript/src/types/hawk-initial-settings.ts
@@ -36,6 +36,8 @@ export interface HawkInitialSettings {
 
   /**
    * How many time we should try to reconnect when connection lost.
+   *
+   * @deprecated not used anymore
    */
   reconnectionAttempts?: number;
 


### PR DESCRIPTION
Since socket reconnection logic changed and its constructor too (#182) we should adapt usages.

Also since `HawkInitialSettings.reconnectionAttempts` is not used anymore it marked as **deprecated**.