### PR TITLE
docs: added deprecation warning to @hawk.so/javascript readme

### DIFF
--- a/packages/javascript/README.md
+++ b/packages/javascript/README.md
@@ -1,5 +1,12 @@
 # Hawk JavaScript Catcher
 
+> [!WARNING]
+> **This package is deprecated.** It has been renamed to [`@hawk.so/browser`](https://www.npmjs.com/package/@hawk.so/browser). Please migrate:
+> ```diff
+> - "@hawk.so/javascript": "..."
+> + "@hawk.so/browser": "..."
+> ```
+
 Error tracking for JavaScript/TypeScript applications.
 
 ## Features


### PR DESCRIPTION
## Summary

Added a deprecation warning to the `@hawk.so/javascript` README pointing users to the new `@hawk.so/browser` package.

The old npm package will be marked as deprecated via the `npm deprecate` command.