### PR TITLE
ci: publish-package workflow with npm version check

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: Publish package to NPM
+name: Publish packages to NPM
 
 on:
   push:
@@ -7,26 +7,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: https://registry.npmjs.org/
-      - run: corepack enable
-      - run: yarn
-      - run: yarn lint-test
-      - run: yarn build:all
-      - run: yarn workspace @hawk.so/core npm publish --access=public
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: yarn workspace @hawk.so/javascript npm publish --access=public
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  publish-core:
+    uses: ./.github/workflows/publish-package.yml
+    with:
+      workspace: '@hawk.so/core'
+      path: packages/core
+    secrets: inherit
+
+  publish-javascript:
+    uses: ./.github/workflows/publish-package.yml
+    with:
+      workspace: '@hawk.so/javascript'
+      path: packages/javascript
+    secrets: inherit
+
   notify:
-    needs: publish
+    needs: [publish-core, publish-javascript]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,40 @@
+name: Publish package to NPM
+
+on:
+  workflow_call:
+    inputs:
+      workspace:
+        required: true
+        type: string
+        description: 'Yarn workspace name'
+      path:
+        required: true
+        type: string
+        description: 'Package directory relative to repo root'
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: https://registry.npmjs.org/
+      - run: corepack enable
+      - run: yarn
+      - run: yarn lint-test
+      - run: yarn build:all
+      - name: Publish ${{ inputs.workspace }}
+        run: |
+          VERSION=$(node -p "require('./${{ inputs.path }}/package.json').version")
+          if npm view "${{ inputs.workspace }}@$VERSION" version &>/dev/null; then
+            echo "${{ inputs.workspace }}@$VERSION already published, skipping"
+          else
+            yarn workspace ${{ inputs.workspace }} npm publish --access=public
+          fi
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/javascript",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "JavaScript errors tracking for Hawk.so",
   "files": [
     "dist"


### PR DESCRIPTION
- Adds `.github/workflows/publish-package.yml` as a reusable workflow
- Each package publish is now an independent job – a version conflict on one does not block the other
- Skips publishing if the version already exists on npm (fixes the issue where unchanged packages caused publish failures)