### PR TITLE
chore: bump @hawk.so/browser version to 3.3.6

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       path: packages/core
     secrets: inherit
 
-  publish-javascript:
+  publish-browser:
     uses: ./.github/workflows/publish-package.yml
     with:
       workspace: '@hawk.so/browser'
@@ -22,7 +22,7 @@ jobs:
     secrets: inherit
 
   notify:
-    needs: [publish-core, publish-javascript]
+    needs: [publish-core, publish-browser]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/browser",
-  "version": "1.0.0",
+  "version": "3.3.6",
   "description": "JavaScript Browser errors tracking for Hawk.so",
   "files": [
     "dist"


### PR DESCRIPTION
`@hawk.so/browser` was bumped from last former @hawk.so/javascript version.

Also ci publishing job name was fixed (`publish-javascript` -> `publish-browser`).